### PR TITLE
Add CacheRoute strategy, KDN knowledge index and pass request context to strategy.select

### DIFF
--- a/core/request.py
+++ b/core/request.py
@@ -527,12 +527,28 @@ class Request:
             if strategy and hasattr(strategy, "select"):
                 # 统一策略接口：要求策略提供 select(proxies, request_obj_like) 或 select(proxies, payload)
                 # 这里为了避免 build_request 依赖 scheduler 的 Request 类型，我们先把最小上下文传给策略：
+                request_ctx = {
+                    "request_id": request_id,
+                    "knowledge_list": list(service_obj.Knowledge_List or []),
+                    "knowledge_length": int(service_obj.Knowledge_length or 0),
+                    "endpoint_type": service_obj.Endpoint_type,
+                    # Injection_type 当前主要用于调试；正式策略不应依赖它做硬分支。
+                    "injection_type": service_obj.Injection_type,
+                    "rag_enabled": bool(service_obj.Enable_know_injection),
+                    "prompt_token_length": int(prompt_obj.token_length or 0),
+                    "user_prompt": user_prompt,
+                    # 下面两个上下文允许策略复用 scheduler 已维护的数据，
+                    # 避免重复做 embedding 或在线拼状态。
+                    "knowledge_table": knowledge_table,
+                    "kdn_knowledge_index": payload.get("_scheduler_kdn_knowledge_index") if isinstance(payload, dict) else None,
+                }
                 chosen_kdn, chosen_proxy = strategy.select(
                     kdns=kdns or [],
                     proxies=proxies or [],
                     payload=payload,
                     url_path=url_path,
                     user_addr=user_addr,
+                    request_ctx=request_ctx,
                 )
 
                 if chosen_kdn:

--- a/scheduler/knowledge/kdn_sync.py
+++ b/scheduler/knowledge/kdn_sync.py
@@ -29,6 +29,58 @@ def _format_kdn_addr(host: str, port: int) -> str:
     return f"kdn://{host}:{int(port)}"
 
 
+async def refresh_kdn_knowledge_index(app) -> Dict[str, Dict[str, Dict[str, int]]]:
+    """
+    为 scheduler 构建一个轻量级 per-KDN 知识元数据索引。
+
+    返回结构：
+      {
+        <kdn_id>: {
+          <kid>: {"length": 123, "kv_ready": 1},
+          ...
+        },
+        "kdn://host:port": {...}  # 兼容地址查询
+      }
+
+    说明：
+    - 这里只拉 metadata，不拉 embedding，避免把知识表构建逻辑和 KDN 选择逻辑混在一起。
+    - 先顺序实现，保持最小改动；后续若 KDN 数量增多，可再并发化。
+    """
+    pool = getattr(app.state, "kdn_pool", None)
+    if pool is None:
+        app.state.kdn_knowledge_index = {}
+        return {}
+
+    alive = await pool.list(include_dead=False)
+    if not alive:
+        app.state.kdn_knowledge_index = {}
+        return {}
+
+    index: Dict[str, Dict[str, Dict[str, int]]] = {}
+    for info in alive:
+        base_url = f"http://{info.host}:{int(info.port)}"
+        items = await fetch_kdn_snapshot(
+            base_url=base_url,
+            need_fields=["kid", "length", "kv_ready"],
+        )
+
+        meta_by_kid: Dict[str, Dict[str, int]] = {}
+        for it in items:
+            kid = str(it.get("kid") or "").strip().lower()
+            if not kid:
+                continue
+            meta_by_kid[kid] = {
+                "length": int(it.get("length") or 0),
+                "kv_ready": int(it.get("kv_ready") or 0),
+            }
+
+        index[str(info.kdn_id)] = meta_by_kid
+        index[_format_kdn_addr(info.host, info.port)] = meta_by_kid
+
+    app.state.kdn_knowledge_index = index
+    return index
+
+
 async def select_kdn_base_url(app) -> tuple[str | None, list[str]]:
     """
     Select one alive KDN server from scheduler's kdn_pool.
@@ -125,6 +177,8 @@ async def kdn_refresh_once(app) -> dict:
         raise RuntimeError("scheduler.state._kdn_refresh_lock is not initialized")
 
     async with lock:
+        kdn_knowledge_index = await refresh_kdn_knowledge_index(app)
+
         kdn_base_url, alive_addrs = await select_kdn_base_url(app)
         if not kdn_base_url:
             app.state.kdn_last_refresh_ok = False
@@ -173,6 +227,8 @@ async def kdn_refresh_once(app) -> dict:
                 unit = KnowledgeUnit(
                     embedding=list(emb),
                     length=int(it.get("length") or 0),
+                    # 当前 KnowledgeTable 继续保留“哪些 KDN 可用”的全局视角；
+                    # 精确到每个 KDN 的覆盖信息由 kdn_knowledge_index 维护，供 cacheroute 使用。
                     avail_kdn_servers=list(alive_addrs),
                     kv_ready=int(it.get("kv_ready") or 0),
                     kv_rel_dir=it.get("kv_rel_dir"),

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -441,14 +441,37 @@ async def create_chat_completions(request: FastAPIRequest):
     # 构建内部 Request（包含 Prompt/Service/Task 等）
     pool = get_pool()
     proxy_infos = await pool.list(include_dead=False)
-    proxies = [{"proxy_id": p.proxy_id, "host": p.host, "port": p.port} for p in proxy_infos]
+    proxies = [
+        {
+            "proxy_id": p.proxy_id,
+            "host": p.host,
+            "port": p.port,
+            "inflight": p.load.inflight,
+            "qps_1m": p.load.qps_1m,
+            "gpu_util": p.load.gpu_util,
+            "meta": dict(p.meta or {}),
+        }
+        for p in proxy_infos
+    ]
 
     kdn_pool = get_kdn_pool()
     kdn_infos = await kdn_pool.list(include_dead=False)
-    kdns = [{"kdn_id": k.kdn_id, "host": k.host, "port": k.port} for k in kdn_infos]
+    kdns = [
+        {
+            "kdn_id": k.kdn_id,
+            "host": k.host,
+            "port": k.port,
+            "items": k.load.items,
+            "qps_1m": k.load.qps_1m,
+            "meta": dict(k.meta or {}),
+        }
+        for k in kdn_infos
+    ]
 
     strategy = getattr(request.app.state, "proxy_strategy", None)
-    req_obj = _handle_client(request.app, url_path, payload, client_ip, proxies=proxies, kdns=kdns, strategy=strategy,)
+    payload_for_build = dict(payload)
+    payload_for_build["_scheduler_kdn_knowledge_index"] = getattr(request.app.state, "kdn_knowledge_index", {})
+    req_obj = _handle_client(request.app, url_path, payload_for_build, client_ip, proxies=proxies, kdns=kdns, strategy=strategy,)
 
     if not req_obj.Task.KDN_server_addr or not req_obj.Task.P_proxy_addr or req_obj.Task.P_proxy_port <= 0:
         raise RuntimeError("Routing failed: missing KDN or Proxy selection")
@@ -531,14 +554,37 @@ async def create_completions(request: FastAPIRequest):
     # 构建内部 Request（包含 Prompt/Service/Task 等）
     pool = get_pool()
     proxy_infos = await pool.list(include_dead=False)
-    proxies = [{"proxy_id": p.proxy_id, "host": p.host, "port": p.port} for p in proxy_infos]
+    proxies = [
+        {
+            "proxy_id": p.proxy_id,
+            "host": p.host,
+            "port": p.port,
+            "inflight": p.load.inflight,
+            "qps_1m": p.load.qps_1m,
+            "gpu_util": p.load.gpu_util,
+            "meta": dict(p.meta or {}),
+        }
+        for p in proxy_infos
+    ]
 
     kdn_pool = get_kdn_pool()
     kdn_infos = await kdn_pool.list(include_dead=False)
-    kdns = [{"kdn_id": k.kdn_id, "host": k.host, "port": k.port} for k in kdn_infos]
+    kdns = [
+        {
+            "kdn_id": k.kdn_id,
+            "host": k.host,
+            "port": k.port,
+            "items": k.load.items,
+            "qps_1m": k.load.qps_1m,
+            "meta": dict(k.meta or {}),
+        }
+        for k in kdn_infos
+    ]
 
     strategy = getattr(request.app.state, "proxy_strategy", None)
-    req_obj = _handle_client(request.app, url_path, payload, client_ip, proxies=proxies, kdns=kdns, strategy=strategy,)
+    payload_for_build = dict(payload)
+    payload_for_build["_scheduler_kdn_knowledge_index"] = getattr(request.app.state, "kdn_knowledge_index", {})
+    req_obj = _handle_client(request.app, url_path, payload_for_build, client_ip, proxies=proxies, kdns=kdns, strategy=strategy,)
 
     if not req_obj.Task.KDN_server_addr or not req_obj.Task.P_proxy_addr or req_obj.Task.P_proxy_port <= 0:
         raise RuntimeError("Routing failed: missing KDN or Proxy selection")

--- a/scheduler/strategy/base.py
+++ b/scheduler/strategy/base.py
@@ -9,7 +9,10 @@ class ProxySelectionStrategy(ABC):
     """
     统一路由策略接口：给一组候选 KDNs + Proxies + 当前 request，
     返回 (chosen_kdn, chosen_proxy)。
-    后续扩展：可以在这里加更多上下文（如历史统计、请求类别、KV信息等）
+
+    request_ctx 采用轻量上下文形式，用来给策略传递已经在 scheduler
+    内部计算完成的信息（例如 Knowledge_List、知识长度、每个 KDN 的知识元数据索引等），
+    避免策略层重复做 embedding 检索。
     """
 
     name: str = "base"
@@ -22,5 +25,6 @@ class ProxySelectionStrategy(ABC):
             payload: Dict[str, Any],
             url_path: str,
             user_addr: str,
+            request_ctx: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
         raise NotImplementedError

--- a/scheduler/strategy/cacheroute.py
+++ b/scheduler/strategy/cacheroute.py
@@ -1,0 +1,187 @@
+# scheduler/strategy/cacheroute.py
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, List, Optional, Tuple
+
+from .base import ProxySelectionStrategy
+
+
+class CacheRouteStrategy(ProxySelectionStrategy):
+    """
+    CacheRoute 调度策略的第一阶段实现。
+
+    当前版本只做最小可用能力：
+    1) 基于 request 的 Knowledge_List，在每个 KDN 的知识元数据索引里判断
+       - 是否能完整提供请求所需知识文本；
+       - 该 KDN 上 kv_ready 覆盖的总长度。
+    2) KDN 选择采用“词典序规则”，避免引入加权打分：
+       - 优先完整文本覆盖；
+       - 优先非过载 KDN；
+       - 再比 kv_ready 覆盖长度；
+       - 最后比轻负载与稳定顺序。
+    3) Proxy 选择先保持保守：优先当前 inflight 最小者，避免一次性把
+       拓扑/历史偏好也同时引入。后续版本再把 KDN 锚点拓扑和知识亲和性接进来。
+
+    备注：
+    - 这里不依赖 Injection_type 做模式分支；正式策略默认先满足文本可服务性，
+      再在可服务候选中偏向 KVCache 覆盖更高的 KDN。
+    - request_ctx / kdn_knowledge_index 由 scheduler 内部准备。
+    """
+
+    name: str = "cacheroute"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._proxy_cursor = 0
+
+    @staticmethod
+    def _kdn_addr(kdn: Dict[str, Any]) -> str:
+        return f"kdn://{kdn['host']}:{int(kdn['port'])}"
+
+    @staticmethod
+    def _proxy_inflight(proxy: Dict[str, Any]) -> int:
+        return int(proxy.get('inflight', 0) or 0)
+
+    @staticmethod
+    def _proxy_qps(proxy: Dict[str, Any]) -> float:
+        return float(proxy.get('qps_1m', 0.0) or 0.0)
+
+    @staticmethod
+    def _proxy_gpu(proxy: Dict[str, Any]) -> float:
+        return float(proxy.get('gpu_util', 0.0) or 0.0)
+
+    @staticmethod
+    def _kdn_items(kdn: Dict[str, Any]) -> int:
+        return int(kdn.get('items', 0) or 0)
+
+    @staticmethod
+    def _kdn_qps(kdn: Dict[str, Any]) -> float:
+        return float(kdn.get('qps_1m', 0.0) or 0.0)
+
+    @staticmethod
+    def _is_overloaded(kdn: Dict[str, Any]) -> bool:
+        """
+        第一阶段先只保留钩子，不引入新的 KDN 负载字段。
+        当前没有专门过载指标时，统一视作未过载；如果后续 heartbeat 已经开始上报，
+        可以通过 meta.overloaded 直接覆盖。
+        """
+        meta = kdn.get('meta') or {}
+        return bool(meta.get('overloaded', False))
+
+    def _select_kdn(
+        self,
+        kdns: List[Dict[str, Any]],
+        knowledge_list: List[str],
+        knowledge_index: Dict[str, Dict[str, Dict[str, Any]]],
+    ) -> Optional[Dict[str, Any]]:
+        if not kdns:
+            return None
+
+        # 没有知识需求时，退化为最轻负载 KDN，避免复杂逻辑干扰原有流程。
+        if not knowledge_list:
+            ranked = sorted(
+                kdns,
+                key=lambda k: (
+                    self._is_overloaded(k),
+                    self._kdn_qps(k),
+                    self._kdn_items(k),
+                    str(k.get('kdn_id', '')),
+                ),
+            )
+            return ranked[0] if ranked else None
+
+        ranked: List[Tuple[Tuple[Any, ...], Dict[str, Any]]] = []
+        for kdn in kdns:
+            kdn_id = str(kdn.get('kdn_id') or '')
+            kdn_addr = self._kdn_addr(kdn)
+
+            # 支持两种索引键：kdn_id 优先，其次 kdn://host:port，方便后续平滑过渡。
+            meta_by_kid = knowledge_index.get(kdn_id) or knowledge_index.get(kdn_addr) or {}
+
+            text_full = True
+            kv_cover_len = 0
+            missing_count = 0
+            for kid in knowledge_list:
+                item = meta_by_kid.get(kid)
+                if item is None:
+                    text_full = False
+                    missing_count += 1
+                    continue
+                if int(item.get('kv_ready', 0) or 0) == 1:
+                    kv_cover_len += int(item.get('length', 0) or 0)
+
+            # 词典序：
+            # 1. 完整文本覆盖优先
+            # 2. 非过载优先
+            # 3. KVCache 覆盖长度越大越优
+            # 4. 缺失知识数越少越优（作为非完整覆盖场景的回退）
+            # 5. QPS / items 越小越优
+            # 6. kdn_id 稳定打破并列
+            key = (
+                0 if text_full else 1,
+                0 if not self._is_overloaded(kdn) else 1,
+                -kv_cover_len,
+                missing_count,
+                self._kdn_qps(kdn),
+                self._kdn_items(kdn),
+                kdn_id,
+            )
+            ranked.append((key, kdn))
+
+        ranked.sort(key=lambda x: x[0])
+        return ranked[0][1] if ranked else None
+
+    def _select_proxy(self, proxies: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        if not proxies:
+            return None
+
+        # 第一阶段保持简单：
+        # - 优先 inflight 最小
+        # - 再比 qps_1m / gpu_util
+        # - 最后使用本地 cursor 做稳定轮换，避免完全固定在一个 proxy 上
+        ranked = sorted(
+            proxies,
+            key=lambda p: (
+                self._proxy_inflight(p),
+                self._proxy_qps(p),
+                self._proxy_gpu(p),
+                str(p.get('proxy_id', '')),
+            ),
+        )
+        best = ranked[0]
+        best_key = (
+            self._proxy_inflight(best),
+            self._proxy_qps(best),
+            self._proxy_gpu(best),
+        )
+        tied = [p for p in ranked if (
+            self._proxy_inflight(p),
+            self._proxy_qps(p),
+            self._proxy_gpu(p),
+        ) == best_key]
+
+        if len(tied) == 1:
+            return best
+
+        with self._lock:
+            idx = self._proxy_cursor % len(tied)
+            self._proxy_cursor += 1
+            return tied[idx]
+
+    def select(
+        self,
+        kdns: List[Dict[str, Any]],
+        proxies: List[Dict[str, Any]],
+        payload: Dict[str, Any],
+        url_path: str,
+        user_addr: str,
+        request_ctx: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        ctx = request_ctx or {}
+        knowledge_list = [str(x).strip().lower() for x in (ctx.get('knowledge_list') or []) if str(x).strip()]
+        knowledge_index = ctx.get('kdn_knowledge_index') or {}
+
+        chosen_kdn = self._select_kdn(kdns=kdns, knowledge_list=knowledge_list, knowledge_index=knowledge_index)
+        chosen_proxy = self._select_proxy(proxies=proxies)
+        return chosen_kdn, chosen_proxy

--- a/scheduler/strategy/factory.py
+++ b/scheduler/strategy/factory.py
@@ -5,11 +5,14 @@ from typing import Dict
 
 from .base import ProxySelectionStrategy
 from .round_robin import RoundRobinStrategy
+from .cacheroute import CacheRouteStrategy
 
 
 _STRATEGIES: Dict[str, type[ProxySelectionStrategy]] = {
     "round_robin": RoundRobinStrategy,
+    "cacheroute": CacheRouteStrategy,
 }
+
 
 def create_strategy(name: str) -> ProxySelectionStrategy:
     key = (name or "").strip().lower()

--- a/scheduler/strategy/round_robin.py
+++ b/scheduler/strategy/round_robin.py
@@ -7,12 +7,12 @@ from typing import Any, Dict, List, Optional, Tuple
 from .base import ProxySelectionStrategy
 
 
-
 class RoundRobinStrategy(ProxySelectionStrategy):
     """
     最简单的 round-robin：
     - 在“当前存活 proxy 列表”上做循环取模
     - 用 threading.Lock 保护 index，避免并发请求打乱顺序
+    - request_ctx 对该策略无用，但保留统一接口，方便 scheduler 无差别调用
     """
 
     name: str = "round_robin"
@@ -29,6 +29,7 @@ class RoundRobinStrategy(ProxySelectionStrategy):
         payload: Dict[str, Any],
         url_path: str,
         user_addr: str,
+        request_ctx: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
         chosen_kdn = None
         chosen_proxy = None

--- a/test/demo_scheduler.py
+++ b/test/demo_scheduler.py
@@ -19,6 +19,7 @@ KDN_BASE_URL = config.KDN_BASE_URL
 dp_port = config.SCHEDULER_DP_PORT
 dp_host = config.SCHEDULER_DP_HOST
 
+
 def main():
     # logging配置
     logging.basicConfig(
@@ -28,7 +29,14 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--strategy", default="round_robin", help="proxy scheduling strategy")
+    parser.add_argument(
+        "--cacheroute",
+        action="store_true",
+        help="shortcut for --strategy cacheroute",
+    )
     args = parser.parse_args()
+
+    strategy_name = "cacheroute" if args.cacheroute else args.strategy
 
     # 把模型路径暴露给 scheduler（scheduler.py 里通过 os.getenv 读取）
     os.environ["SCHEDULER_MODEL_PATH"] = MODEL_PATH
@@ -38,8 +46,7 @@ def main():
     os.environ["SCHEDULER_EMBEDDING_MODEL"] = EMBEDDING_MODEL
     os.environ["HF_HUB_OFFLINE"] = "1"
     os.environ["TRANSFORMERS_OFFLINE"] = "1"
-    os.environ["SCHEDULER_STRATEGY"] = args.strategy
-
+    os.environ["SCHEDULER_STRATEGY"] = strategy_name
 
     # 配置 uvicorn.Server
     config = uvicorn.Config(scheduler, host=dp_host, port=dp_port, reload=False)
@@ -50,4 +57,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
### Motivation
- Provide a scheduler-side lightweight per-KDN knowledge metadata index so strategies can reason about which KDN can satisfy knowledge/RAG requests without re-fetching embeddings. 
- Enable richer routing decisions by passing a normalized `request_ctx` into proxy/kdn selection strategies. 
- Implement a first-phase CacheRoute strategy to pick KDNs that best cover requested knowledge and choose less-loaded proxies accordingly. 

### Description
- Added `refresh_kdn_knowledge_index` in `scheduler/knowledge/kdn_sync.py` to fetch per-KDN metadata (`kid` -> `length`/`kv_ready`) and store it on `app.state.kdn_knowledge_index`, and integrated its usage into `kdn_refresh_once`. 
- Extended the strategy API in `scheduler/strategy/base.py` to accept an optional `request_ctx` and updated `round_robin` to keep the unified signature. 
- Implemented `CacheRouteStrategy` in `scheduler/strategy/cacheroute.py` that ranks KDNs by text coverage / KV cache coverage / overload status and selects proxies by `inflight`/`qps`/`gpu_util` with stable tie-breaking. 
- Registered the new strategy in `scheduler/strategy/factory.py` and added a `--cacheroute` shortcut in `test/demo_scheduler.py`. 
- Enriched scheduler internals in `scheduler/scheduler.py` to prepare and pass `request_ctx` (including `kdn_knowledge_index`, `knowledge_list`, and other lightweight fields) and to send richer `proxies`/`kdns` metadata into strategy selection; adapted `core/request.py` to include `request_ctx` when calling `strategy.select`. 

### Testing
- Performed smoke import and instantiation checks by importing `scheduler`, `CacheRouteStrategy`, and calling `select` with simple/dummy inputs, which succeeded. 
- Launched the demo startup path (`demo_scheduler`) with the `--cacheroute` shortcut to verify environment wiring and that the scheduler initializes without immediate exceptions. 
- No new automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b622edcd888320a8d5f9519081ee5f)