### PR TITLE
Add unique UUID prefix to generated prompts and fix README path

### DIFF
--- a/instance/TTFT_predictor/README.md
+++ b/instance/TTFT_predictor/README.md
@@ -99,7 +99,7 @@ asyncio.run(main())
 如果你希望调度器通过 HTTP 调用预测服务，直接运行：
 
 ```bash
-cd example/scheduler/TTFT_predictor
+cd instance/TTFT_predictor
 python prefill_prediction_server.py
 ```
 

--- a/instance/TTFT_predictor/request_generator.py
+++ b/instance/TTFT_predictor/request_generator.py
@@ -2,15 +2,30 @@ import asyncio
 import aiohttp
 from transformers import AutoTokenizer
 from typing import Optional
+from uuid import uuid4
 
 def generate_prompt_with_tokens(tokenizer, target_token_count: int) -> str:
     """使用指定的 tokenizer 生成一个包含大致数量 token 的 prompt。"""
-    if target_token_count <= 0: return ""
+    if target_token_count <= 0:
+        return ""
+
+    # 为每次请求加入唯一前缀，降低长 prompt 场景下的前缀重用概率。
+    uuid_prefix = f"request_uuid={uuid4()} "
+    prefix_token_ids = tokenizer.encode(uuid_prefix, add_special_tokens=False)
+    if not prefix_token_ids:
+        return "Error"
+
+    if len(prefix_token_ids) >= target_token_count:
+        return tokenizer.decode(prefix_token_ids[:target_token_count])
+
     base_text = "This is a long context test to measure the performance of the system. "
     base_token_ids = tokenizer.encode(base_text, add_special_tokens=False)
-    if not base_token_ids: return "Error"
-    estimated_repeats = (target_token_count // len(base_token_ids)) + 1
-    prompt_ids = (base_token_ids * estimated_repeats)[:target_token_count]
+    if not base_token_ids:
+        return "Error"
+
+    remain_token_count = target_token_count - len(prefix_token_ids)
+    estimated_repeats = (remain_token_count // len(base_token_ids)) + 1
+    prompt_ids = prefix_token_ids + (base_token_ids * estimated_repeats)[:remain_token_count]
     return tokenizer.decode(prompt_ids)
 
 async def send_test_request(


### PR DESCRIPTION
### Motivation
- Reduce long-prompt prefix reuse by adding a per-request unique prefix to generated prompts in `generate_prompt_with_tokens` to better simulate diverse contexts and avoid cache/reuse artifacts.
- Make prompt generation more robust for edge cases such as non-positive `target_token_count` and when the prefix already meets the requested token count.
- Correct the example `cd` path in the README to point to the actual `instance/TTFT_predictor` directory.

### Description
- Updated `request_generator.py` to import `uuid4` and prepend a `uuid_prefix` to each generated prompt inside `generate_prompt_with_tokens` so each request has a unique leading token sequence.
- Added guards in `generate_prompt_with_tokens` to handle `target_token_count <= 0`, to return an error when tokenization fails, and to return a truncated decoded prefix when the prefix alone meets the `target_token_count` requirement, and to combine prefix + base tokens to reach the exact token count.
- Minor formatting and newline fixes in `request_generator.py` exception handling, and updated the README example command from `cd example/scheduler/TTFT_predictor` to `cd instance/TTFT_predictor`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdbf9a4fe48320b61d4cc273565ae9)