### PR TITLE
prefill_regressor: add per-request TTFT logging and failure reports

### DIFF
--- a/instance/TTFT_predictor/prefill_regressor.py
+++ b/instance/TTFT_predictor/prefill_regressor.py
@@ -156,6 +156,17 @@ class PrefillTimeRegressor:
                             )
                     
                     results = await asyncio.gather(*tasks)
+                    for task_idx, ttft in enumerate(results, start=1):
+                        if ttft is None:
+                            print(
+                                f"[TTFT] BS={bs}, PL={pl}, repeat={i+1}, "
+                                f"task={task_idx}/{bs}, ttft=FAILED"
+                            )
+                        else:
+                            print(
+                                f"[TTFT] BS={bs}, PL={pl}, repeat={i+1}, "
+                                f"task={task_idx}/{bs}, ttft={ttft*1000:.2f}ms"
+                            )
 
                     # 记录同一轮内每个请求的 TTFT，并转成相对 round_start 的首 token 到达时刻。
                     # 注意：arrival_offsets 主要用于观测是否出现“伪串行”，训练样本默认用请求 TTFT 的均值。


### PR DESCRIPTION
### Motivation
- Surface per-request TTFT and explicit failure notices during prefill runs to aid debugging and detect sporadic request failures or large dispatch gaps.

### Description
- After `await asyncio.gather(*tasks)` in `instance/TTFT_predictor/prefill_regressor.py` add a loop that logs each task's TTFT or `FAILED` with `BS`, `PL`, `repeat`, and `task` index, formatting successful TTFTs in milliseconds.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46cf2d1708320b1eee3895065bb95)