### PR TITLE
Ensure generated prompts reach target token counts with noise injection and padding

### DIFF
--- a/instance/TTFT_predictor/prompt_length_validation.log
+++ b/instance/TTFT_predictor/prompt_length_validation.log
@@ -1,0 +1,6 @@
+[check] python -m py_compile instance/TTFT_predictor/request_generator.py
+[check] mock tokenizer minimum-length validation
+target=1, actual=1, ok=True
+target=32, actual=65, ok=True
+target=128, actual=152, ok=True
+target=512, actual=533, ok=True

--- a/instance/TTFT_predictor/request_generator.py
+++ b/instance/TTFT_predictor/request_generator.py
@@ -20,7 +20,7 @@ def _timehash_uuid() -> str:
     return str(uuid.UUID(digest32))
 
 def generate_prompt_with_tokens(tokenizer, target_token_count: int) -> str:
-    """使用指定的 tokenizer 生成一个包含大致数量 token 的 prompt。"""
+    """使用指定的 tokenizer 生成一个 token 数不小于目标值的 prompt。"""
     if target_token_count <= 0:
         return ""
 
@@ -30,30 +30,45 @@ def generate_prompt_with_tokens(tokenizer, target_token_count: int) -> str:
     if not prefix_token_ids:
         return "Error"
 
-    if len(prefix_token_ids) >= target_token_count:
-        return tokenizer.decode(prefix_token_ids[:target_token_count])
+    prompt_ids = list(prefix_token_ids)
 
-    base_text = "This is a long context test to measure the performance of the system. "
-    base_token_ids = tokenizer.encode(base_text, add_special_tokens=False)
-    if not base_token_ids:
-        return "Error"
+    if len(prompt_ids) < target_token_count:
+        base_text = "This is a long context test to measure the performance of the system. "
+        base_token_ids = tokenizer.encode(base_text, add_special_tokens=False)
+        if not base_token_ids:
+            return "Error"
 
-    remain_token_count = target_token_count - len(prefix_token_ids)
-    body_token_ids = []
-    inject_interval = 4  # 每 4 个基础块插入一次随机噪声块，降低长 prompt 重用概率
-    chunk_idx = 0
-    while len(body_token_ids) < remain_token_count:
-        body_token_ids.extend(base_token_ids)
-        chunk_idx += 1
+        remain_token_count = target_token_count - len(prompt_ids)
+        body_token_ids = []
+        inject_interval = 4  # 每 4 个基础块插入一次随机噪声块，降低长 prompt 重用概率
+        chunk_idx = 0
+        while len(body_token_ids) < remain_token_count:
+            body_token_ids.extend(base_token_ids)
+            chunk_idx += 1
 
-        if chunk_idx % inject_interval == 0:
-            noise_text = f"noise={_timehash_uuid().replace('-', '')[:8]} "
-            noise_token_ids = tokenizer.encode(noise_text, add_special_tokens=False)
-            if noise_token_ids:
-                body_token_ids.extend(noise_token_ids)
+            if chunk_idx % inject_interval == 0:
+                noise_text = f"noise={_timehash_uuid().replace('-', '')[:8]} "
+                noise_token_ids = tokenizer.encode(noise_text, add_special_tokens=False)
+                if noise_token_ids:
+                    body_token_ids.extend(noise_token_ids)
 
-    prompt_ids = prefix_token_ids + body_token_ids[:remain_token_count]
-    return tokenizer.decode(prompt_ids)
+        prompt_ids.extend(body_token_ids[:remain_token_count])
+    else:
+        prompt_ids = prompt_ids[:target_token_count]
+
+    prompt = tokenizer.decode(prompt_ids, skip_special_tokens=False)
+
+    # decode 后重新 tokenize 时，token 数可能因分词边界变化略小于 target。
+    # 这里做二次补齐，保证最终 prompt 的 token 数 >= target_token_count（允许略超）。
+    final_token_ids = tokenizer.encode(prompt, add_special_tokens=False)
+    if len(final_token_ids) >= target_token_count:
+        return prompt
+
+    padding_text = " padding_chunk_for_ttft_measurement."
+    while len(final_token_ids) < target_token_count:
+        prompt += padding_text
+        final_token_ids = tokenizer.encode(prompt, add_special_tokens=False)
+    return prompt
 
 async def send_test_request(
     session: aiohttp.ClientSession, 


### PR DESCRIPTION
### Motivation

- Guarantee that generated prompts have token counts not smaller than a requested target to make TTFT measurements reliable.
- Reduce prompt reuse by injecting small, variable noise blocks into long generated contexts.
- Add basic validation/logging of tokenization behavior for common target sizes.

### Description

- Reworked `generate_prompt_with_tokens` to build `prompt_ids` from a unique `request_uuid` prefix and fill remaining tokens with repeated base blocks and injected noise every 4 chunks using `_timehash_uuid`.
- After decoding the token ids back to text, re-tokenize and append a `padding_chunk_for_ttft_measurement` repeatedly to ensure the final token count is `>=` the `target_token_count` (handles tokenizer boundary changes).
- Adjusted docstring and minor control flow to return early on error cases and to truncate when the prefix alone already meets the target, and added a new validation log file `instance/TTFT_predictor/prompt_length_validation.log` capturing sample checks.

### Testing

- Ran `python -m py_compile instance/TTFT_predictor/request_generator.py` which succeeded. 
- Ran mock tokenizer minimum-length validation checks recorded in `instance/TTFT_predictor/prompt_length_validation.log` for targets `1`, `32`, `128`, and `512`, all reported `ok=True`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5d3fd8960832082ec8fb6ac86ffa8)