### PR TITLE
Add decode timeline placeholder fields to proxy queue prediction

### DIFF
--- a/proxy/queue/manager.py
+++ b/proxy/queue/manager.py
@@ -136,6 +136,8 @@ class QueueManager:
             # In current ordered-dispatch mode, forward start follows reservation prefill start.
             forward_start_s = prefill_start_s
             first_token_s = prefill_start_s + compute_s
+            decode_s = 0.0   # Step1: keep decode modeling disabled to preserve current behavior.
+            forward_end_s = first_token_s + decode_s
 
             slot_free[slot_idx] = first_token_s
             self._instance_prefill_free_ts_s[task.instance_id] = first_token_s
@@ -147,6 +149,9 @@ class QueueManager:
             task.pred_forward_start_ts_ms = int(forward_start_s * 1000)
             task.pred_prefill_start_ts_ms = int(prefill_start_s * 1000)
             task.pred_first_token_ts_ms = int(first_token_s * 1000)
+            task.pred_decode_ms = int(decode_s * 1000)
+            task.pred_forward_end_ts_ms = int(forward_end_s * 1000)
+            task.pred_worker_free_ts_ms = int(forward_end_s * 1000)
             task.pred_service_ms = int(compute_s * 1000)
             task.reservation_seq = int(reservation_seq)
             task.recompute_generation = 0
@@ -157,9 +162,13 @@ class QueueManager:
             # queue_wait: ready_enqueue -> predicted forward_start
             task.trace["predict_queue_wait_ms"] = max(0, int((forward_start_s - ready_enqueue_s) * 1000))
             task.trace["predict_compute_ms"] = int(compute_s * 1000)
+            task.trace["predict_decode_ms"] = task.pred_decode_ms
             # vllm_internal: from forward_start to first_token, includes vllm queue + prefill compute
             task.trace["predict_vllm_internal_ms"] = max(0, int((first_token_s - forward_start_s) * 1000))
             task.trace["predict_total_ms"] = int((know_prepare_s + (first_token_s - ready_enqueue_s)) * 1000)
+            task.trace["pred_first_token_ts_ms"] = task.pred_first_token_ts_ms
+            task.trace["pred_forward_end_ts_ms"] = task.pred_forward_end_ts_ms
+            task.trace["pred_worker_free_ts_ms"] = task.pred_worker_free_ts_ms
             # compatibility field
             task.trace["predict_wait_ms"] = int(know_prepare_ms)
 
@@ -214,12 +223,16 @@ class QueueManager:
                 forward_start_s = prefill_start_s
                 service_s = max(0.0, task.pred_service_ms / 1000.0)
                 first_token_s = prefill_start_s + service_s
+                decode_s = task.pred_decode_ms / 1000.0
+                forward_end_s = first_token_s + decode_s
 
                 task.pred_slot_idx = int(slot_idx)
                 task.pred_slot_ready_ts_ms = int(slot_ready_s * 1000)
                 task.pred_forward_start_ts_ms = int(forward_start_s * 1000)
                 task.pred_prefill_start_ts_ms = int(prefill_start_s * 1000)
                 task.pred_first_token_ts_ms = int(first_token_s * 1000)
+                task.pred_forward_end_ts_ms = int(forward_end_s * 1000)
+                task.pred_worker_free_ts_ms = int(forward_end_s * 1000)
                 task.recompute_generation += 1
 
                 know_prepare_ms = int(task.trace.get("predict_know_prepare_ms", 0) or 0)
@@ -227,6 +240,9 @@ class QueueManager:
                 task.trace["predict_queue_wait_ms"] = max(0, int((forward_start_s - ready_enqueue_s) * 1000))
                 task.trace["predict_vllm_internal_ms"] = max(0, int((first_token_s - forward_start_s) * 1000))
                 task.trace["predict_total_ms"] = int(know_prepare_ms + (first_token_s - ready_enqueue_s) * 1000)
+                task.trace["pred_first_token_ts_ms"] = task.pred_first_token_ts_ms
+                task.trace["pred_forward_end_ts_ms"] = task.pred_forward_end_ts_ms
+                task.trace["pred_worker_free_ts_ms"] = task.pred_worker_free_ts_ms
 
                 slot_free[slot_idx] = first_token_s
                 prefill_cursor_s = first_token_s
@@ -551,7 +567,8 @@ class QueueManager:
 
                                 logger.info(
                                     "[Timing] rid=%s instance=%s "
-                                    "pred(total/know_prepare/queue_wait/vllm_internal)=%s/%s/%s/%s ms "
+                                    "pred(total/know_prepare/queue_wait/vllm_internal/decode)=%s/%s/%s/%s/%s ms "
+                                    "pred_ts(first_token/forward_end/worker_free)=%s/%s/%s "
                                     "actual(total/know_prepare/ready_queue/vllm_internal)=%s/%s/%s/%s ms "
                                     "predict_error=%s ms",
                                     task.request_id,
@@ -560,6 +577,10 @@ class QueueManager:
                                     task.trace.get("predict_know_prepare_ms"),
                                     task.trace.get("predict_queue_wait_ms"),
                                     task.trace.get("predict_vllm_internal_ms"),
+                                    task.trace.get("predict_decode_ms"),
+                                    task.trace.get("pred_first_token_ts_ms"),
+                                    task.trace.get("pred_forward_end_ts_ms"),
+                                    task.trace.get("pred_worker_free_ts_ms"),
                                     task.trace.get("actual_total_ms"),
                                     task.trace.get("actual_know_prepare_ms"),
                                     task.trace.get("actual_ready_queue_ms"),

--- a/proxy/queue/task.py
+++ b/proxy/queue/task.py
@@ -58,6 +58,9 @@ class ProxyTask:
     pred_forward_start_ts_ms: int = 0
     pred_prefill_start_ts_ms: int = 0
     pred_first_token_ts_ms: int = 0
+    pred_decode_ms: int = 0
+    pred_forward_end_ts_ms: int = 0
+    pred_worker_free_ts_ms: int = 0
     pred_service_ms: int = 0
     has_started_forward: bool = False
     has_seen_first_token: bool = False


### PR DESCRIPTION
### Motivation
- Prepare for per-request Decode-phase prediction by separating first-token timeline from worker-free timeline without changing current scheduling behavior.
- Add lightweight observability so future steps can enable decode modeling and adjust slot release rules incrementally.

### Description
- Add three new fields to `ProxyTask`: `pred_decode_ms`, `pred_forward_end_ts_ms`, and `pred_worker_free_ts_ms` with default `0` to represent decode duration and forward/worker-free timestamps (`proxy/queue/task.py`).
- In `_reserve_ready_task()` compute a `decode_s` placeholder set to `0.0`, derive `forward_end_s`, and write `pred_decode_ms`, `pred_forward_end_ts_ms`, and `pred_worker_free_ts_ms` into the task and `task.trace` while keeping `slot_free` and `prefill_free` updates anchored at `first_token_s` (behavior unchanged) (`proxy/queue/manager.py`).
- In `_recompute_pending_from_now()` propagate the decode placeholder from `task.pred_decode_ms` to recomputed `pred_forward_end_ts_ms` and `pred_worker_free_ts_ms`, and update trace fields accordingly while preserving existing slot/prefill logic (`proxy/queue/manager.py`).
- Enrich the existing Timing log line with lightweight fields: `predict_decode_ms`, `pred_first_token_ts_ms`, `pred_forward_end_ts_ms`, and `pred_worker_free_ts_ms` for debug/observability only (`proxy/queue/manager.py`).

### Testing
- Ran `python -m py_compile proxy/queue/task.py proxy/queue/manager.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e742b43f7c83209a441d158c84f74e)