### PR TITLE
kdn: record real transfer timestamps when network simulator is off

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -7,7 +7,7 @@
 
 
 CacheRoute支持大规模推理资源池互联与调度。为便于展示CacheRoute的功能，config内为便于展示demo，使用的是环回地址进行Scheduler、proxy、instance和kdn_server的配置，若设备允许，开展跨机实验，需要将地址进行拆分。这里以拆分KDN_server为例，proxy、instance的地址配置与kdn_server类似<br>
-（1）需要确保连通性的KDN服务器与推理服务器，这里假设KDN服务器地址为`172.18.0.171`，推理服务器地址为`172.18.0.169`<br>
+（1）需要确保连通性的KDN服务器与推理服务器，这里假设KDN服务器地址为`172.18.10.171`，推理服务器地址为`172.18.0.169`<br>
 （2）在169设备的config中配置scheduler信息`SCHEDULER_BASE_URL = "http://172.18.0.169:7001"`，`SCHEDULER_CP_URL   = "http://172.18.0.169:7002"`，`SCHEDULER_DP_HOST = "0.0.0.0"`，`SCHEDULER_CP_HOST = "0.0.0.0"`<br>
 （3）在169设备的config中配置proxy信息`PROXY_BASE_URL = "http://172.18.0.169:8001"`，`PROXY_CP_URL   = "http://172.18.0.169:8002"`，`PROXY_DP_HOST = "0.0.0.0"`，`PROXY_CP_HOST = "0.0.0.0"`<br>
 （4）在169设备的config中配置instance信息`INSTANCE_BASE_URL = "http://172.18.0.169:9001"`,`INSTANCE_HOST = "0.0.0.0"`,`INSTANCE_CP_HOST = "0.0.0.0"`,`INSTANCE_REDIS_HOST = "127.0.0.1"`,`INSTANCE_TOPOLOGY_KDN_TARGETS = "http://172.18.10.171:9101"`<br>

--- a/kdn_server/kdn_api.py
+++ b/kdn_server/kdn_api.py
@@ -839,6 +839,7 @@ async def inject_ready_kv(payload: Dict[str, Any]):
         try:
             res = injector.inject_kv_dir(kv_dir)
             redis_done_ts = time.perf_counter()
+            transfer_start_ts = time.time()
 
             net_result = {
                 "batch_id": None,
@@ -846,6 +847,8 @@ async def inject_ready_kv(payload: Dict[str, Any]):
                 "network_queue_ms": 0.0,
                 "network_transfer_ms": 0.0,
                 "network_total_ms": 0.0,
+                "transfer_start_ts": transfer_start_ts,
+                "transfer_end_ts": transfer_start_ts,
             }
 
             if _NETWORK_SIM is not None and int(res.payload_bytes) > 0:
@@ -854,6 +857,13 @@ async def inject_ready_kv(payload: Dict[str, Any]):
                     payload_bytes=int(res.payload_bytes),
                     ready_time=redis_done_ts,
                 )
+                net_result["transfer_start_ts"] = transfer_start_ts
+                net_result["transfer_end_ts"] = time.time()
+            else:
+                # 未开启网络模拟器时，记录真实时间戳与真实耗时，便于实验观测。
+                transfer_end_ts = time.time()
+                net_result["transfer_end_ts"] = transfer_end_ts
+                net_result["network_total_ms"] = max(0.0, (transfer_end_ts - transfer_start_ts) * 1000.0)
 
             # 只有真正注入完成 + 网络模拟完成后才记 success
             injected_kids.append(kid)
@@ -864,7 +874,8 @@ async def inject_ready_kv(payload: Dict[str, Any]):
             logging.info(
                 "[KDN] inject_ready_kv ok: kid=%s kv_dir=%s injected=%s missing_files=%s "
                 "payload_bytes=%s payload_files=%s batch_id=%s batch_size=%s "
-                "network_queue_ms=%.3f network_transfer_ms=%.3f network_total_ms=%.3f",
+                "network_queue_ms=%.3f network_transfer_ms=%.3f network_total_ms=%.3f "
+                "transfer_start_ts=%.6f transfer_end_ts=%.6f",
                 kid,
                 kv_dir,
                 res.injected,
@@ -876,6 +887,8 @@ async def inject_ready_kv(payload: Dict[str, Any]):
                 net_result["network_queue_ms"],
                 net_result["network_transfer_ms"],
                 net_result["network_total_ms"],
+                net_result["transfer_start_ts"],
+                net_result["transfer_end_ts"],
             )
 
         except Exception as e:


### PR DESCRIPTION
### Motivation
- Ensure KDN emits real wall-clock transfer timestamps and a meaningful `network_total_ms` even when the `NetworkSimulator` is disabled to improve observability for experiments.

### Description
- Update `inject_ready_kv` in `kdn_server/kdn_api.py` to capture `transfer_start_ts = time.time()` before transfer and always include `transfer_start_ts`/`transfer_end_ts` in `net_result` and logs.
- When `_NETWORK_SIM` is present, preserve simulator behavior and attach the real `transfer_start_ts` and a `transfer_end_ts` taken after the simulator call; when `_NETWORK_SIM` is `None`, compute `network_total_ms` from the real elapsed wall-clock time.
- Extend the success log line to include `transfer_start_ts` and `transfer_end_ts` for both simulator-on and simulator-off modes to make timestamps directly visible in logs.

### Testing
- Ran `python -m py_compile kdn_server/kdn_api.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbf297facc8320bbdf12035a3e6cef)