### PR TITLE
proxy: add ready-release CLI and fix text_bypass release cursor progression

### DIFF
--- a/proxy/queue/manager.py
+++ b/proxy/queue/manager.py
@@ -6,7 +6,7 @@ import time
 import httpx
 import asyncio
 import logging
-from typing import Dict, Optional, AsyncGenerator, Any, List
+from typing import Dict, Optional, AsyncGenerator, Any, List, Set
 
 from core import forward_request,config
 from proxy.metrics.queue_predictor import queue_predictor, decode_tpot_predictor, predict_redis_pull_ms
@@ -71,6 +71,7 @@ class QueueManager:
         self._instance_next_prepare_seq: Dict[str, int] = {}
         self._instance_next_ready_release_seq: Dict[str, int] = {}
         self._instance_prepared_buffer: Dict[str, Dict[int, ProxyTask]] = {}
+        self._instance_released_prepare_seqs: Dict[str, Set[int]] = {}
         self._reservation_locks: Dict[str, asyncio.Lock] = {}
         self._prepared_flush_locks: Dict[str, asyncio.Lock] = {}
         self._kdn_kv_link_free_ts_s: Dict[str, float] = {}
@@ -88,6 +89,11 @@ class QueueManager:
         self._ready_release_policy = ready_release_policy
         self._text_bypass_max_per_flush = max(
             1, int(os.environ.get("PROXY_TEXT_BYPASS_MAX_PER_FLUSH", "1") or 1)
+        )
+        logger.info(
+            "[Queue] ready_release_policy=%s text_bypass_max_per_flush=%s",
+            self._ready_release_policy,
+            self._text_bypass_max_per_flush,
         )
 
     def _get_kdn_kv_link_lock(self, link_key: str) -> asyncio.Lock:
@@ -253,6 +259,8 @@ class QueueManager:
             self._instance_next_ready_release_seq[instance_id] = 1
         if instance_id not in self._instance_prepared_buffer:
             self._instance_prepared_buffer[instance_id] = {}
+        if instance_id not in self._instance_released_prepare_seqs:
+            self._instance_released_prepare_seqs[instance_id] = set()
 
     async def _mark_prepare_done_and_flush(self, instance_id: str, task: ProxyTask) -> None:
         lock = self._get_prepared_flush_lock(instance_id)
@@ -273,6 +281,7 @@ class QueueManager:
         blocked_seq: Optional[int],
     ) -> None:
         del buf[seq]
+        self._instance_released_prepare_seqs.setdefault(instance_id, set()).add(int(seq))
         task.trace["ready_release_seq"] = int(seq)
         task.trace["ready_release_policy"] = str(self._ready_release_policy)
         task.trace["ready_release_bypass"] = 1 if bypass else 0
@@ -305,8 +314,12 @@ class QueueManager:
         q = self._qmap.get(instance_id)
         buf = self._instance_prepared_buffer.get(instance_id, {})
         next_seq = int(self._instance_next_ready_release_seq.get(instance_id, 1) or 1)
+        released = self._instance_released_prepare_seqs.get(instance_id, set())
         bypass_count = 0
         while True:
+            while next_seq in released:
+                next_seq += 1
+
             task = buf.get(next_seq)
             if task is not None:
                 await self._release_prepared_task_to_ready(

--- a/test/demo_proxy.py
+++ b/test/demo_proxy.py
@@ -41,6 +41,13 @@ if __name__ == "__main__":
         default=None,
         help="proxy injection strategy (default|iws)",
     )
+    parser.add_argument(
+        "--ready-release-policy",
+        type=str,
+        default=None,
+        choices=("ordered", "text_bypass"),
+        help="ready release policy (ordered|text_bypass)",
+    )
     args = parser.parse_args()
 
     if args.strategy:
@@ -52,6 +59,8 @@ if __name__ == "__main__":
         os.environ["PROXY_INJECTION_STRATEGY"] = normalized
     if args.kdn_links_json and str(args.kdn_links_json).strip():
         os.environ["PROXY_KDN_LINKS_JSON"] = args.kdn_links_json
+    if args.ready_release_policy:
+        os.environ["PROXY_READY_RELEASE_POLICY"] = args.ready_release_policy
 
     from proxy import proxy  # 确保在设置环境变量后导入
 


### PR DESCRIPTION
### Motivation

- Make `text_bypass` selectable at startup (not only via env vars) and observable at QueueManager initialization. 
- Prevent `_instance_next_ready_release_seq` from stalling when a higher sequence is bypass-released earlier and later removed from the prepared buffer.

### Description

- Add `--ready-release-policy` CLI option to the proxy launcher (`test/demo_proxy.py`) and set `PROXY_READY_RELEASE_POLICY` before importing `proxy` so import-time `QueueManager` reads the selected policy. 
- Add a startup info log in `QueueManager.__init__`: `[Queue] ready_release_policy=%s text_bypass_max_per_flush=%s` for observability. 
- Introduce per-instance released-prepared-seqs tracking: `_instance_released_prepare_seqs: Dict[str, Set[int]]`, initialized in `_ensure_instance_reservation_state`. 
- Record every released prepare `seq` into `_instance_released_prepare_seqs` inside `_release_prepared_task_to_ready(...)`. 
- In `_flush_prepared_to_ready(...)` skip any `next_seq` values that are already recorded as released so the cursor advances past sequences that have been bypass-released and removed from the buffer. 
- Preserve conservative bypass semantics: only `text` candidates are eligible, `ordered` mode logs `[BypassCandidate]`, `text_bypass` logs `[Bypass]` and respects the per-flush cap (`PROXY_TEXT_BYPASS_MAX_PER_FLUSH`), and all releases still call `_reserve_ready_task` to keep reservation ordering for dispatch.

### Testing

- Compiled modified modules with `python3 -m py_compile test/demo_proxy.py proxy/queue/manager.py` and the compile succeeded. 
- Manual runtime validation notes prepared: starting proxy without `--ready-release-policy` keeps `ordered` behavior, and starting with `--ready-release-policy text_bypass` will emit the new `[Queue] ready_release_policy=...` log and show `[ReadyRelease][Bypass]` for eligible text candidates while ensuring the ready-release cursor does not stall on previously bypassed seqs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc0c9a1408320b7e51f2c06569a77)