### PR TITLE
perf_client: add forward-stage wait metrics and trace diagnostics

### DIFF
--- a/client/perf_client.py
+++ b/client/perf_client.py
@@ -45,6 +45,33 @@ def is_stream(body: Dict[str, Any]) -> bool:
     return parse_bool(body.get("stream", False))
 
 
+def check_trace_order(trace: Dict[str, int]) -> List[str]:
+    ordered_keys = [
+        "proxy_enqueue_ms",
+        "prepare_start_ms",
+        "ready_enqueue_ms",
+        "ready_dequeue_ms",
+        "forward_start_ms",
+        "first_token_ms",
+    ]
+    warnings: List[str] = []
+
+    prev_key: Optional[str] = None
+    prev_val: Optional[int] = None
+    for key in ordered_keys:
+        if key not in trace:
+            continue
+        current_val = int(trace[key])
+        if prev_key is not None and prev_val is not None and current_val < prev_val:
+            warnings.append(
+                f"trace timestamp order violation: {prev_key}={prev_val} > {key}={current_val}"
+            )
+        prev_key = key
+        prev_val = current_val
+
+    return warnings
+
+
 def calc_metrics(trace: Dict[str, int]) -> Dict[str, Optional[int]]:
     def duration(start_key: str, end_key: str) -> Optional[int]:
         if start_key in trace and end_key in trace:
@@ -54,6 +81,7 @@ def calc_metrics(trace: Dict[str, int]) -> Dict[str, Optional[int]]:
     prepare_queue_wait_ms = duration("proxy_enqueue_ms", "prepare_start_ms")
     prepare_exec_ms = duration("prepare_start_ms", "ready_enqueue_ms")
     ready_queue_wait_ms = duration("ready_enqueue_ms", "ready_dequeue_ms")
+    ready_dequeue_to_forward_ms = duration("ready_dequeue_ms", "forward_start_ms")
     instance_exec_to_first_token_ms = duration("forward_start_ms", "first_token_ms")
 
     total_prefill_ms = duration("proxy_enqueue_ms", "first_token_ms")
@@ -64,6 +92,18 @@ def calc_metrics(trace: Dict[str, int]) -> Dict[str, Optional[int]]:
     proxy_queue_wait_ms = None
     if prepare_queue_wait_ms is not None or ready_queue_wait_ms is not None:
         proxy_queue_wait_ms = (prepare_queue_wait_ms or 0) + (ready_queue_wait_ms or 0)
+    proxy_wait_until_forward_ms = None
+    if (
+        prepare_queue_wait_ms is not None
+        or ready_queue_wait_ms is not None
+        or ready_dequeue_to_forward_ms is not None
+    ):
+        proxy_wait_until_forward_ms = (
+            (prepare_queue_wait_ms or 0)
+            + (ready_queue_wait_ms or 0)
+            + (ready_dequeue_to_forward_ms or 0)
+        )
+    proxy_enqueue_to_forward_ms = duration("proxy_enqueue_ms", "forward_start_ms")
 
     knowledge_preparation_total_ms = prepare_exec_ms
     vllm_compute_to_first_token_ms = instance_exec_to_first_token_ms
@@ -76,11 +116,14 @@ def calc_metrics(trace: Dict[str, int]) -> Dict[str, Optional[int]]:
         "knowledge_fetch_ms": knowledge_fetch_ms,
         "knowledge_preparation_total_ms": knowledge_preparation_total_ms,
         "vllm_compute_to_first_token_ms": vllm_compute_to_first_token_ms,
+        "proxy_wait_until_forward_ms": proxy_wait_until_forward_ms,
+        "proxy_enqueue_to_forward_ms": proxy_enqueue_to_forward_ms,
 
         # 新拆细口径
         "prepare_queue_wait_ms": prepare_queue_wait_ms,
         "prepare_exec_ms": prepare_exec_ms,
         "ready_queue_wait_ms": ready_queue_wait_ms,
+        "ready_dequeue_to_forward_ms": ready_dequeue_to_forward_ms,
         "instance_exec_to_first_token_ms": instance_exec_to_first_token_ms,
         "kv_ack_ms": kv_ack_ms,
     }
@@ -260,6 +303,7 @@ async def run_one(
 
     trace = meta.get("trace", {}) if isinstance(meta, dict) else {}
     metrics = calc_metrics(trace if isinstance(trace, dict) else {})
+    trace_warnings = check_trace_order(trace if isinstance(trace, dict) else {})
 
     client_send_delay_ms: Optional[int] = None
     if scheduled_send_ts is not None:
@@ -279,6 +323,7 @@ async def run_one(
         "text_only_kids": meta.get("text_only_kids", []) if isinstance(meta, dict) else [],
         "error": meta.get("error") if isinstance(meta, dict) else None,
         "injection_type": actual_injection_type,
+        "trace_warnings": trace_warnings,
         "rag": body.get("RAG"),
         "stream": body.get("stream"),
         "request_body": body,
@@ -294,6 +339,7 @@ def summarize(
     total_elapsed_s: float,
     peak_inflight: int,
     target_rps: Optional[float] = None,
+    print_trace: bool = False,
 ) -> None:
     def fmt(v: Any) -> str:
         return "N/A" if v is None else str(v)
@@ -311,7 +357,8 @@ def summarize(
     print("=" * 160)
     print(
         "idx | name | injection | status | total_prefill_ms | "
-        "proxy_before_vllm_ms | proxy_queue_wait_ms | knowledge_fetch_ms | "
+        "proxy_before_vllm_ms | proxy_queue_wait_ms | ready_dequeue_to_forward_ms | "
+        "proxy_wait_until_forward_ms | proxy_enqueue_to_forward_ms | knowledge_fetch_ms | "
         "knowledge_preparation_total_ms | vllm_compute_to_first_token_ms | "
         "client_send_delay_ms | wall_ms | error"
     )
@@ -327,6 +374,9 @@ def summarize(
             f"{fmt(m.get('total_prefill_ms'))} | "
             f"{fmt(m.get('proxy_before_vllm_ms'))} | "
             f"{fmt(m.get('proxy_queue_wait_ms'))} | "
+            f"{fmt(m.get('ready_dequeue_to_forward_ms'))} | "
+            f"{fmt(m.get('proxy_wait_until_forward_ms'))} | "
+            f"{fmt(m.get('proxy_enqueue_to_forward_ms'))} | "
             f"{fmt(m.get('knowledge_fetch_ms'))} | "
             f"{fmt(m.get('knowledge_preparation_total_ms'))} | "
             f"{fmt(m.get('vllm_compute_to_first_token_ms'))} | "
@@ -349,6 +399,9 @@ def summarize(
         ("prepare_queue_wait_ms", "Average prepare queue wait time"),
         ("prepare_exec_ms", "Average prepare execution time"),
         ("ready_queue_wait_ms", "Average ready queue wait time"),
+        ("ready_dequeue_to_forward_ms", "Average wait after ready dequeue before forward"),
+        ("proxy_wait_until_forward_ms", "Average total proxy wait until forward"),
+        ("proxy_enqueue_to_forward_ms", "Average proxy enqueue to forward time"),
         ("instance_exec_to_first_token_ms", "Average instance execution to first token"),
         ("kv_ack_ms", "Average kv ack time"),
     ]
@@ -376,6 +429,19 @@ def summarize(
     if delay_vals:
         print(f"Average client send delay: {int(statistics.mean(delay_vals))} ms")
 
+    if print_trace:
+        print("\n" + "=" * 160)
+        print("Per Request Trace JSON")
+        print("=" * 160)
+        for r in results:
+            print(json.dumps({
+                "idx": r.get("req_index"),
+                "name": r.get("name"),
+                "injection": r.get("injection_type"),
+                "trace": r.get("trace", {}),
+                "metrics": r.get("metrics", {}),
+            }, ensure_ascii=False, indent=2))
+
     print(f"Mode: {mode}")
     if target_rps is not None:
         print(f"Target RPS: {target_rps}")
@@ -383,6 +449,18 @@ def summarize(
     if total_elapsed_s > 0:
         print(f"Actual throughput: {len(results) / total_elapsed_s:.3f} req/s")
     print(f"Peak inflight requests: {peak_inflight}")
+
+    warning_results = [
+        (r.get("req_index"), r.get("trace_warnings", []))
+        for r in results
+        if r.get("trace_warnings")
+    ]
+    if warning_results:
+        print("\nTrace order warnings:")
+        for req_idx, warnings in warning_results:
+            for warning in warnings:
+                print(f"  - idx={req_idx}: {warning}")
+
     print("=" * 160)
 
 
@@ -509,6 +587,7 @@ async def main_async(args: argparse.Namespace) -> None:
         total_elapsed_s=(exp_end - exp_start),
         peak_inflight=peak_inflight,
         target_rps=args.rps if args.mode == "rps" else None,
+        print_trace=args.print_trace,
     )
 
 
@@ -603,6 +682,11 @@ def main() -> None:
         "--knowledge-ids",
         default=None,
         help="comma-separated knowledge ids applied globally",
+    )
+    parser.add_argument(
+        "--print-trace",
+        action="store_true",
+        help="print per-request trace and metrics as JSON",
     )
 
     args = parser.parse_args()

--- a/client/perf_client.py
+++ b/client/perf_client.py
@@ -47,10 +47,24 @@ def is_stream(body: Dict[str, Any]) -> bool:
 
 def check_trace_order(trace: Dict[str, int]) -> List[str]:
     ordered_keys = [
+        "proxy_recv_ms",
         "proxy_enqueue_ms",
+        "prepare_queue_enqueue_ms",
+        "prepare_dequeue_ms",
         "prepare_start_ms",
+        "kdn_fetch_start_ms",
+        "kdn_fetch_end_ms",
+        "kv_ack_start_ms",
+        "kv_ack_end_ms",
+        "kv_inject_queue_enqueue_ms",
+        "kv_inject_start_ms",
+        "kv_inject_end_ms",
+        "text_prefill_build_start_ms",
+        "text_prefill_build_end_ms",
         "ready_enqueue_ms",
         "ready_dequeue_ms",
+        "forward_wait_start_ms",
+        "forward_wait_end_ms",
         "forward_start_ms",
         "first_token_ms",
     ]
@@ -78,16 +92,29 @@ def calc_metrics(trace: Dict[str, int]) -> Dict[str, Optional[int]]:
             return int(trace[end_key]) - int(trace[start_key])
         return None
 
-    prepare_queue_wait_ms = duration("proxy_enqueue_ms", "prepare_start_ms")
+    proxy_admission_ms = duration("proxy_recv_ms", "proxy_enqueue_ms")
+    route_select_ms = duration("route_select_start_ms", "route_select_end_ms")
+    prepare_queue_wait_ms = duration("prepare_queue_enqueue_ms", "prepare_dequeue_ms")
+    if prepare_queue_wait_ms is None:
+        prepare_queue_wait_ms = duration("proxy_enqueue_ms", "prepare_start_ms")
+    prepare_worker_gap_ms = duration("prepare_dequeue_ms", "prepare_start_ms")
     prepare_exec_ms = duration("prepare_start_ms", "ready_enqueue_ms")
+    prepare_total_ms = duration("prepare_start_ms", "ready_enqueue_ms")
     ready_queue_wait_ms = duration("ready_enqueue_ms", "ready_dequeue_ms")
+    forward_wait_ms = duration("forward_wait_start_ms", "forward_wait_end_ms")
     ready_dequeue_to_forward_ms = duration("ready_dequeue_ms", "forward_start_ms")
-    instance_exec_to_first_token_ms = duration("forward_start_ms", "first_token_ms")
+    vllm_first_token_ms = duration("forward_start_ms", "first_token_ms")
+    instance_exec_to_first_token_ms = vllm_first_token_ms
 
     total_prefill_ms = duration("proxy_enqueue_ms", "first_token_ms")
     proxy_before_vllm_ms = duration("proxy_enqueue_ms", "forward_start_ms")
+    proxy_recv_to_forward_ms = duration("proxy_recv_ms", "forward_start_ms")
     knowledge_fetch_ms = duration("kdn_fetch_start_ms", "kdn_fetch_end_ms")
+    kdn_fetch_ms = knowledge_fetch_ms
     kv_ack_ms = duration("kv_ack_start_ms", "kv_ack_end_ms")
+    kv_inject_queue_wait_ms = duration("kv_inject_queue_enqueue_ms", "kv_inject_start_ms")
+    kv_inject_exec_ms = duration("kv_inject_start_ms", "kv_inject_end_ms")
+    text_prefill_build_ms = duration("text_prefill_build_start_ms", "text_prefill_build_end_ms")
 
     proxy_queue_wait_ms = None
     if prepare_queue_wait_ms is not None or ready_queue_wait_ms is not None:
@@ -118,15 +145,46 @@ def calc_metrics(trace: Dict[str, int]) -> Dict[str, Optional[int]]:
         "vllm_compute_to_first_token_ms": vllm_compute_to_first_token_ms,
         "proxy_wait_until_forward_ms": proxy_wait_until_forward_ms,
         "proxy_enqueue_to_forward_ms": proxy_enqueue_to_forward_ms,
+        "proxy_recv_to_forward_ms": proxy_recv_to_forward_ms,
+        "proxy_admission_ms": proxy_admission_ms,
+        "route_select_ms": route_select_ms,
 
         # 新拆细口径
         "prepare_queue_wait_ms": prepare_queue_wait_ms,
+        "prepare_worker_gap_ms": prepare_worker_gap_ms,
         "prepare_exec_ms": prepare_exec_ms,
+        "prepare_total_ms": prepare_total_ms,
         "ready_queue_wait_ms": ready_queue_wait_ms,
+        "forward_wait_ms": forward_wait_ms,
         "ready_dequeue_to_forward_ms": ready_dequeue_to_forward_ms,
+        "kdn_fetch_ms": kdn_fetch_ms,
+        "kv_inject_queue_wait_ms": kv_inject_queue_wait_ms,
+        "kv_inject_exec_ms": kv_inject_exec_ms,
+        "text_prefill_build_ms": text_prefill_build_ms,
+        "vllm_first_token_ms": vllm_first_token_ms,
         "instance_exec_to_first_token_ms": instance_exec_to_first_token_ms,
         "kv_ack_ms": kv_ack_ms,
     }
+
+
+def check_trace_integrity(trace: Dict[str, int], injection_type: str) -> List[str]:
+    warnings: List[str] = []
+    mode = str(injection_type or "").strip().lower()
+    if mode == "kvcache":
+        required_pairs = [
+            ("kdn_fetch_start_ms", "kdn_fetch_end_ms"),
+            ("kv_ack_start_ms", "kv_ack_end_ms"),
+            ("kv_inject_start_ms", "kv_inject_end_ms"),
+        ]
+        for sk, ek in required_pairs:
+            if sk not in trace or ek not in trace:
+                warnings.append(f"kvcache trace missing {sk}/{ek}")
+    if mode == "text":
+        if "text_prefill_build_start_ms" not in trace or "text_prefill_build_end_ms" not in trace:
+            warnings.append("text trace missing text_prefill_build_start_ms/text_prefill_build_end_ms")
+        if "prepare_start_ms" not in trace or "ready_enqueue_ms" not in trace:
+            warnings.append("text trace missing prepare_start_ms/ready_enqueue_ms")
+    return warnings
 
 
 async def read_chat_stream_meta(
@@ -304,6 +362,7 @@ async def run_one(
     trace = meta.get("trace", {}) if isinstance(meta, dict) else {}
     metrics = calc_metrics(trace if isinstance(trace, dict) else {})
     trace_warnings = check_trace_order(trace if isinstance(trace, dict) else {})
+    trace_warnings.extend(check_trace_integrity(trace if isinstance(trace, dict) else {}, actual_injection_type))
 
     client_send_delay_ms: Optional[int] = None
     if scheduled_send_ts is not None:
@@ -358,7 +417,10 @@ def summarize(
     print(
         "idx | name | injection | status | total_prefill_ms | "
         "proxy_before_vllm_ms | proxy_queue_wait_ms | ready_dequeue_to_forward_ms | "
-        "proxy_wait_until_forward_ms | proxy_enqueue_to_forward_ms | knowledge_fetch_ms | "
+        "proxy_wait_until_forward_ms | proxy_enqueue_to_forward_ms | proxy_recv_to_forward_ms | "
+        "prepare_queue_wait_ms | prepare_worker_gap_ms | kdn_fetch_ms | kv_ack_ms | "
+        "kv_inject_queue_wait_ms | kv_inject_exec_ms | text_prefill_build_ms | "
+        "ready_queue_wait_ms | forward_wait_ms | knowledge_fetch_ms | "
         "knowledge_preparation_total_ms | vllm_compute_to_first_token_ms | "
         "client_send_delay_ms | wall_ms | error"
     )
@@ -377,6 +439,16 @@ def summarize(
             f"{fmt(m.get('ready_dequeue_to_forward_ms'))} | "
             f"{fmt(m.get('proxy_wait_until_forward_ms'))} | "
             f"{fmt(m.get('proxy_enqueue_to_forward_ms'))} | "
+            f"{fmt(m.get('proxy_recv_to_forward_ms'))} | "
+            f"{fmt(m.get('prepare_queue_wait_ms'))} | "
+            f"{fmt(m.get('prepare_worker_gap_ms'))} | "
+            f"{fmt(m.get('kdn_fetch_ms'))} | "
+            f"{fmt(m.get('kv_ack_ms'))} | "
+            f"{fmt(m.get('kv_inject_queue_wait_ms'))} | "
+            f"{fmt(m.get('kv_inject_exec_ms'))} | "
+            f"{fmt(m.get('text_prefill_build_ms'))} | "
+            f"{fmt(m.get('ready_queue_wait_ms'))} | "
+            f"{fmt(m.get('forward_wait_ms'))} | "
             f"{fmt(m.get('knowledge_fetch_ms'))} | "
             f"{fmt(m.get('knowledge_preparation_total_ms'))} | "
             f"{fmt(m.get('vllm_compute_to_first_token_ms'))} | "
@@ -402,6 +474,17 @@ def summarize(
         ("ready_dequeue_to_forward_ms", "Average wait after ready dequeue before forward"),
         ("proxy_wait_until_forward_ms", "Average total proxy wait until forward"),
         ("proxy_enqueue_to_forward_ms", "Average proxy enqueue to forward time"),
+        ("proxy_recv_to_forward_ms", "Average proxy recv to forward time"),
+        ("proxy_admission_ms", "Average proxy admission time"),
+        ("route_select_ms", "Average route select time"),
+        ("prepare_worker_gap_ms", "Average prepare worker gap time"),
+        ("prepare_total_ms", "Average prepare total time"),
+        ("kdn_fetch_ms", "Average KDN fetch time"),
+        ("kv_inject_queue_wait_ms", "Average KV inject queue wait time"),
+        ("kv_inject_exec_ms", "Average KV inject execution time"),
+        ("text_prefill_build_ms", "Average text prefill build time"),
+        ("forward_wait_ms", "Average forward wait time"),
+        ("vllm_first_token_ms", "Average vLLM first token time"),
         ("instance_exec_to_first_token_ms", "Average instance execution to first token"),
         ("kv_ack_ms", "Average kv ack time"),
     ]

--- a/client/perf_client.py
+++ b/client/perf_client.py
@@ -415,7 +415,7 @@ def summarize(
     print("Compact Request Performance Summary")
     print("=" * 160)
     print(
-        "idx | name | injection | status | total_prefill_ms | "
+        "idx | name | injection | server_injection_mode | text_actual_path | kvcache_actual_path | status | total_prefill_ms | "
         "proxy_before_vllm_ms | proxy_queue_wait_ms | ready_dequeue_to_forward_ms | "
         "proxy_wait_until_forward_ms | proxy_enqueue_to_forward_ms | proxy_recv_to_forward_ms | "
         "prepare_queue_wait_ms | prepare_worker_gap_ms | kdn_fetch_ms | kv_ack_ms | "
@@ -428,10 +428,14 @@ def summarize(
 
     for r in results:
         m = r["metrics"]
+        t = r.get("trace", {}) if isinstance(r.get("trace"), dict) else {}
         print(
             f"{r['req_index']:03d} | "
             f"{r['name']} | "
             f"{r['injection_type']} | "
+            f"{fmt(t.get('injection_mode'))} | "
+            f"{fmt(t.get('text_actual_path'))} | "
+            f"{fmt(t.get('kvcache_actual_path'))} | "
             f"{r['http_status']} | "
             f"{fmt(m.get('total_prefill_ms'))} | "
             f"{fmt(m.get('proxy_before_vllm_ms'))} | "

--- a/client/perf_client.py
+++ b/client/perf_client.py
@@ -46,42 +46,32 @@ def is_stream(body: Dict[str, Any]) -> bool:
 
 
 def check_trace_order(trace: Dict[str, int]) -> List[str]:
-    ordered_keys = [
-        "proxy_recv_ms",
-        "proxy_enqueue_ms",
-        "prepare_queue_enqueue_ms",
-        "prepare_dequeue_ms",
-        "prepare_start_ms",
-        "kdn_fetch_start_ms",
-        "kdn_fetch_end_ms",
-        "kv_ack_start_ms",
-        "kv_ack_end_ms",
-        "kv_inject_queue_enqueue_ms",
-        "kv_inject_start_ms",
-        "kv_inject_end_ms",
-        "text_prefill_build_start_ms",
-        "text_prefill_build_end_ms",
-        "ready_enqueue_ms",
-        "ready_dequeue_ms",
-        "forward_wait_start_ms",
-        "forward_wait_end_ms",
-        "forward_start_ms",
-        "first_token_ms",
-    ]
     warnings: List[str] = []
-
-    prev_key: Optional[str] = None
-    prev_val: Optional[int] = None
-    for key in ordered_keys:
-        if key not in trace:
+    ordered_pairs = [
+        ("proxy_recv_ms", "proxy_enqueue_ms"),
+        ("prepare_queue_enqueue_ms", "prepare_dequeue_ms"),
+        ("prepare_dequeue_ms", "prepare_start_ms"),
+        ("kdn_fetch_start_ms", "kdn_fetch_end_ms"),
+        ("kv_inject_queue_enqueue_ms", "kv_inject_start_ms"),
+        ("kv_inject_start_ms", "kv_ack_start_ms"),
+        ("kv_ack_start_ms", "kv_ack_end_ms"),
+        ("kv_ack_end_ms", "kv_inject_end_ms"),
+        ("text_prefill_build_start_ms", "text_prefill_build_end_ms"),
+        ("ready_enqueue_ms", "ready_dequeue_ms"),
+        ("ready_dequeue_ms", "forward_wait_start_ms"),
+        ("forward_wait_start_ms", "forward_wait_end_ms"),
+        ("forward_wait_end_ms", "forward_start_ms"),
+        ("forward_start_ms", "first_token_ms"),
+    ]
+    for left_key, right_key in ordered_pairs:
+        if left_key not in trace or right_key not in trace:
             continue
-        current_val = int(trace[key])
-        if prev_key is not None and prev_val is not None and current_val < prev_val:
+        left_val = int(trace[left_key])
+        right_val = int(trace[right_key])
+        if right_val < left_val:
             warnings.append(
-                f"trace timestamp order violation: {prev_key}={prev_val} > {key}={current_val}"
+                f"trace timestamp order violation: {left_key}={left_val} > {right_key}={right_val}"
             )
-        prev_key = key
-        prev_val = current_val
 
     return warnings
 
@@ -164,6 +154,12 @@ def calc_metrics(trace: Dict[str, int]) -> Dict[str, Optional[int]]:
         "vllm_first_token_ms": vllm_first_token_ms,
         "instance_exec_to_first_token_ms": instance_exec_to_first_token_ms,
         "kv_ack_ms": kv_ack_ms,
+        "actual_prepare_total_ms": trace.get("actual_prepare_total_ms"),
+        "prepare_buffer_wait_ms": trace.get("prepare_buffer_wait_ms"),
+        "actual_ready_queue_ms": trace.get("actual_ready_queue_ms"),
+        "actual_vllm_internal_ms": trace.get("actual_vllm_internal_ms"),
+        "predict_queue_wait_ms": trace.get("predict_queue_wait_ms"),
+        "predict_error_ms": trace.get("predict_error_ms"),
     }
 
 
@@ -171,19 +167,23 @@ def check_trace_integrity(trace: Dict[str, int], injection_type: str) -> List[st
     warnings: List[str] = []
     mode = str(injection_type or "").strip().lower()
     if mode == "kvcache":
-        required_pairs = [
-            ("kdn_fetch_start_ms", "kdn_fetch_end_ms"),
-            ("kv_ack_start_ms", "kv_ack_end_ms"),
-            ("kv_inject_start_ms", "kv_inject_end_ms"),
-        ]
-        for sk, ek in required_pairs:
-            if sk not in trace or ek not in trace:
-                warnings.append(f"kvcache trace missing {sk}/{ek}")
+        path = str(trace.get("kvcache_actual_path", "") or "")
+        if path == "kv_inject":
+            required_pairs = [
+                ("kdn_fetch_start_ms", "kdn_fetch_end_ms"),
+                ("kv_ack_start_ms", "kv_ack_end_ms"),
+                ("kv_inject_start_ms", "kv_inject_end_ms"),
+            ]
+            for sk, ek in required_pairs:
+                if sk not in trace or ek not in trace:
+                    warnings.append(f"kvcache trace missing {sk}/{ek}")
     if mode == "text":
-        if "text_prefill_build_start_ms" not in trace or "text_prefill_build_end_ms" not in trace:
-            warnings.append("text trace missing text_prefill_build_start_ms/text_prefill_build_end_ms")
-        if "prepare_start_ms" not in trace or "ready_enqueue_ms" not in trace:
-            warnings.append("text trace missing prepare_start_ms/ready_enqueue_ms")
+        path = str(trace.get("text_actual_path", "") or "")
+        if path == "text_inject":
+            if "text_prefill_build_start_ms" not in trace or "text_prefill_build_end_ms" not in trace:
+                warnings.append("text trace missing text_prefill_build_start_ms/text_prefill_build_end_ms")
+            if "prepare_start_ms" not in trace or "ready_enqueue_ms" not in trace:
+                warnings.append("text trace missing prepare_start_ms/ready_enqueue_ms")
     return warnings
 
 
@@ -487,6 +487,12 @@ def summarize(
         ("vllm_first_token_ms", "Average vLLM first token time"),
         ("instance_exec_to_first_token_ms", "Average instance execution to first token"),
         ("kv_ack_ms", "Average kv ack time"),
+        ("actual_prepare_total_ms", "Average actual prepare total time"),
+        ("prepare_buffer_wait_ms", "Average prepare buffer wait time"),
+        ("actual_ready_queue_ms", "Average actual ready queue time"),
+        ("actual_vllm_internal_ms", "Average actual vLLM internal time"),
+        ("predict_queue_wait_ms", "Average predict queue wait time"),
+        ("predict_error_ms", "Average predict error time"),
     ]
 
     for metric_key, metric_label in metric_names:
@@ -741,7 +747,7 @@ def main() -> None:
     parser.add_argument(
         "--max-tokens",
         type=int,
-        default=64,
+        default=1,
         help="max tokens",
     )
     parser.add_argument(

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -19,6 +19,7 @@ import os
 import json
 import asyncio
 import logging
+import time
 import uvicorn
 
 from contextlib import asynccontextmanager
@@ -447,6 +448,7 @@ async def proxy_chat_completions(request: FastAPIRequest):
     接收来自 Scheduler 的 /v1/chat/completions 请求（payload为 Request JSON）。
     转发为 OpenAI chat/completions body 到 Worker（流式）
     """
+    proxy_recv_ms = int(time.time() * 1000)
     try:
         payload: Dict[str, Any] = await request.json()
     except Exception as e:
@@ -469,7 +471,9 @@ async def proxy_chat_completions(request: FastAPIRequest):
     # 构造 Instance 请求体
     instance_body = build_body_for_instance(req_obj, mode="chat")
 
+    route_select_start_ms = int(time.time() * 1000)
     chosen = select_instance(proxy, req_obj)
+    route_select_end_ms = int(time.time() * 1000)
     if not chosen:
         return JSONResponse(
             status_code=503,
@@ -588,6 +592,9 @@ async def proxy_chat_completions(request: FastAPIRequest):
             kdn_addr=getattr(req_obj.Task, "KDN_server_addr", None),
             url_path=url_path,
         )
+        task.trace["proxy_recv_ms"] = proxy_recv_ms
+        task.trace["route_select_start_ms"] = route_select_start_ms
+        task.trace["route_select_end_ms"] = route_select_end_ms
 
         await queue_mgr.enqueue_prepare(task)
 
@@ -609,6 +616,7 @@ async def proxy_completions(request: FastAPIRequest):
     接收来自 Scheduler 的 /v1/completions 请求。
     Demo 里逻辑与 chat/completions 相同，只是留出扩展空间。
     """
+    proxy_recv_ms = int(time.time() * 1000)
     try:
         payload: Dict[str, Any] = await request.json()
     except Exception as e:
@@ -631,7 +639,9 @@ async def proxy_completions(request: FastAPIRequest):
     # 构造 Instance 请求体
     instance_body = build_body_for_instance(req_obj, mode="completions")
 
+    route_select_start_ms = int(time.time() * 1000)
     chosen = select_instance(proxy, req_obj)
+    route_select_end_ms = int(time.time() * 1000)
     if not chosen:
         return JSONResponse(
             status_code=503,
@@ -750,6 +760,9 @@ async def proxy_completions(request: FastAPIRequest):
             kdn_addr=getattr(req_obj.Task, "KDN_server_addr", None),
             url_path=url_path,
         )
+        task.trace["proxy_recv_ms"] = proxy_recv_ms
+        task.trace["route_select_start_ms"] = route_select_start_ms
+        task.trace["route_select_end_ms"] = route_select_end_ms
 
         await queue_mgr.enqueue_prepare(task)
 

--- a/proxy/queue/manager.py
+++ b/proxy/queue/manager.py
@@ -788,7 +788,9 @@ class QueueManager:
             logger.warning("[Predict] rid=%s failed: %s", task.request_id, e)
 
         q = self._qmap.get(task.instance_id)
-        task.trace["proxy_enqueue_ms"] = _now_ms()
+        enqueue_ms = _now_ms()
+        task.trace["proxy_enqueue_ms"] = enqueue_ms
+        task.trace["prepare_queue_enqueue_ms"] = enqueue_ms
 
         await q.prepare_q.put(task)
         logger.info(
@@ -854,12 +856,16 @@ class QueueManager:
                     )
 
                     endpoint_type = getattr(svc, "Endpoint_type", "chat/completions")
+                    if str(injection_type).strip().lower() == "text":
+                        task.trace["text_prefill_build_start_ms"] = _now_ms()
                     task.instance_body = inject_rag_into_instance_body(
                         instance_body=task.instance_body,
                         endpoint_type=endpoint_type,
                         retrieved_context=ctx,
                         injection_type=injection_type,
                     )
+                    if str(injection_type).strip().lower() == "text":
+                        task.trace["text_prefill_build_end_ms"] = _now_ms()
                     task.trace["prompt_injected_ms"] = _now_ms()
 
                     task.kv_ready_kids = [
@@ -917,11 +923,18 @@ class QueueManager:
                                 task.trace["predict_prepare_ms"] = int(task.trace["predict_know_prepare_ms"])
                                 task.trace["predict_prepare_model_ms"] = int(task.trace["predict_prepare_ms"])
                                 if kv_queue_wait_s > 0:
+                                    task.trace["kv_inject_queue_enqueue_ms"] = int(task.trace.get("kv_inject_queue_enqueue_ms", int(now_s * 1000.0)) or int(now_s * 1000.0))
+                                    task.trace["kv_inject_start_ms"] = int(start_s * 1000.0)
                                     await asyncio.sleep(kv_queue_wait_s)
+                                else:
+                                    instant_ms = _now_ms()
+                                    task.trace["kv_inject_queue_enqueue_ms"] = int(task.trace.get("kv_inject_queue_enqueue_ms", instant_ms) or instant_ms)
+                                    task.trace["kv_inject_start_ms"] = int(task.trace.get("kv_inject_start_ms", instant_ms) or instant_ms)
                                 task.trace["kv_link_reserved"] = 1
                                 task.trace["kv_ack_start_ms"] = _now_ms()
                                 kv_ack = await self._inject_ready_kv_via_instance(task)
                                 task.trace["kv_ack_end_ms"] = _now_ms()
+                                task.trace["kv_inject_end_ms"] = int(task.trace.get("kv_ack_end_ms", _now_ms()) or _now_ms())
                                 task.trace["prepare_self_done_ms"] = int(task.trace.get("kv_ack_end_ms", 0) or 0)
                                 kv_ack_end_ms = float(task.trace.get("kv_ack_end_ms", 0) or 0)
                                 kv_ack_start_ms = float(task.trace.get("kv_ack_start_ms", 0) or 0)
@@ -1057,6 +1070,7 @@ class QueueManager:
             try:
                 task.trace["ready_dequeue_ms"] = _now_ms()
                 task.trace["ready_worker_idx"] = worker_idx
+                task.trace["forward_wait_start_ms"] = _now_ms()
                 await self._wait_dispatch_turn(task, instance_id)
 
                 target_url = f"http://{task.instance_host}:{task.instance_port}{task.url_path}"
@@ -1071,6 +1085,7 @@ class QueueManager:
 
                 # use_chunked: chat->True, completions->False（由 task.url_path 决定）
                 use_chunked = True if task.url_path.endswith("/chat/completions") else False
+                task.trace["forward_wait_end_ms"] = _now_ms()
                 task.trace["forward_start_ms"] = _now_ms()
 
                 seen_first_chunk = False
@@ -1218,6 +1233,7 @@ class QueueManager:
         q = self._qmap.get(instance_id)
         while True:
             task = await q.prepare_q.get()
+            task.trace["prepare_dequeue_ms"] = _now_ms()
             asyncio.create_task(self._run_prepare_task(instance_id, task))
 
     async def _inject_ready_kv_via_instance(

--- a/proxy/queue/manager.py
+++ b/proxy/queue/manager.py
@@ -825,8 +825,9 @@ class QueueManager:
                 enable_rag = bool(getattr(svc, "Enable_know_injection", False))
                 knowledge_ids = getattr(svc, "Knowledge_List", []) or []
                 injection_type = getattr(svc, "Injection_type", "text")
+                injection_mode = str(injection_type or "text").strip().lower()
 
-                if enable_rag and knowledge_ids and injection_type in ("text", "kvcache"):
+                if enable_rag and knowledge_ids and injection_mode in ("text", "kvcache"):
                     kdn_addr = (task.kdn_addr or "").strip()
                     if not kdn_addr:
                         logger.warning("[Prepare] rid=%s no kdn_addr", task.request_id)
@@ -856,7 +857,8 @@ class QueueManager:
                     )
 
                     endpoint_type = getattr(svc, "Endpoint_type", "chat/completions")
-                    if str(injection_type).strip().lower() == "text":
+                    if injection_mode == "text":
+                        task.trace["text_actual_path"] = "text_inject"
                         task.trace["text_prefill_build_start_ms"] = _now_ms()
                     task.instance_body = inject_rag_into_instance_body(
                         instance_body=task.instance_body,
@@ -864,7 +866,7 @@ class QueueManager:
                         retrieved_context=ctx,
                         injection_type=injection_type,
                     )
-                    if str(injection_type).strip().lower() == "text":
+                    if injection_mode == "text":
                         task.trace["text_prefill_build_end_ms"] = _now_ms()
                     task.trace["prompt_injected_ms"] = _now_ms()
 
@@ -889,9 +891,10 @@ class QueueManager:
                         q.active_prepare,
                     )
 
-                    if injection_type == "kvcache":
+                    if injection_mode == "kvcache":
                         if task.kv_ready_kids:
                             try:
+                                task.trace["kvcache_actual_path"] = "kv_inject"
                                 kdn_addr = str(task.kdn_addr or "").strip()
                                 link_key = f"{task.instance_id}|{kdn_addr or 'unknown'}"
                                 kv_transfer_s = await self._predict_kv_transfer_s(task)
@@ -999,7 +1002,9 @@ class QueueManager:
                                     kv_ack.get("keys_injected", 0),
                                 )
                             except Exception as e:
+                                task.trace["kvcache_actual_path"] = "kv_inject_failed_fallback_text"
                                 task.trace["kv_ack_end_ms"] = _now_ms()
+                                task.trace["kv_inject_end_ms"] = int(task.trace.get("kv_ack_end_ms", _now_ms()) or _now_ms())
                                 task.trace["prepare_self_done_ms"] = int(task.trace.get("kv_ack_end_ms", 0) or 0)
                                 pending = self._kdn_kv_pending_tasks.get(link_key, [])
                                 self._kdn_kv_pending_tasks[link_key] = [x for x in pending if x is not task]
@@ -1014,6 +1019,7 @@ class QueueManager:
                                 logger.exception("[Prepare] rid=%s kv inject ack failed, fallback text-only",
                                                  task.request_id)
                         else:
+                            task.trace["kvcache_actual_path"] = "no_kv_ready_fallback_text"
                             kdn_addr = str(task.kdn_addr or "").strip()
                             link_key = f"{task.instance_id}|{kdn_addr or 'unknown'}"
                             pending = self._kdn_kv_pending_tasks.get(link_key, [])
@@ -1028,12 +1034,14 @@ class QueueManager:
                             }
                             logger.info("[Prepare] rid=%s no kv_ready_kids, fallback text-only", task.request_id)
                 else:
+                    if injection_mode == "text":
+                        task.trace["text_actual_path"] = "no_rag_or_empty_knowledge"
                     logger.info(
                         "[Prepare] skip knowledge injection request_id(rid)=%s enable_rag=%s injection=None kids=%s",
                         task.request_id, enable_rag, len(knowledge_ids)
                     )
 
-                if str(injection_type).strip().lower() == "text":
+                if injection_mode == "text":
                     prepare_done_ms = _now_ms()
                     task.trace["prepare_self_done_ms"] = prepare_done_ms
                     proxy_enqueue_ms = int(task.trace.get("proxy_enqueue_ms", prepare_done_ms) or prepare_done_ms)


### PR DESCRIPTION
### Motivation

- Client-side proxy wait metrics were undercounting time between ready dequeue and actual forward to vLLM, causing proxy_queue_wait_ms to appear too small when server-side showed queuing. 
- The goal is to minimally extend the existing metrics and output so experiments keep the same behavior while exposing the missing wait stage for research and validation.

### Description

- Modified `client/perf_client.py` to add three new metrics computed from the server trace: `ready_dequeue_to_forward_ms` (`ready_dequeue_ms -> forward_start_ms`), `proxy_wait_until_forward_ms` (sum of `prepare_queue_wait_ms + ready_queue_wait_ms + ready_dequeue_to_forward_ms` but only computed if at least one segment exists), and `proxy_enqueue_to_forward_ms` (`proxy_enqueue_ms -> forward_start_ms`), while keeping the legacy `proxy_queue_wait_ms` and `proxy_before_vllm_ms` unchanged for compatibility.
- Added `check_trace_order(trace)` that validates monotonic order across `proxy_enqueue_ms`, `prepare_start_ms`, `ready_enqueue_ms`, `ready_dequeue_ms`, `forward_start_ms`, `first_token_ms` and returns per-request `trace_warnings` when timestamps are out of order.
- Extended the compact request summary to include `ready_dequeue_to_forward_ms`, `proxy_wait_until_forward_ms`, and `proxy_enqueue_to_forward_ms`, and extended the average summary `metric_names` with the three metrics and their descriptive labels.
- Added CLI flag `--print-trace` (off by default) which, when enabled, prints per-request JSON with `idx`, `name`, `injection`, `trace`, and `metrics` using `ensure_ascii=False` and `indent=2`; trace-order warnings are grouped and printed at the end of the summary.

### Testing

- Compiled the modified file with `python -m py_compile client/perf_client.py` which succeeded. 
- The change preserves request sending flow and concurrent/rps behavior and retains legacy output fields for backwards compatibility, so existing automated experiment flows remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bcee22854832081a6681157aff1f2)