### PR TITLE
Translate client comments to English

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -1,22 +1,16 @@
-"""
-client.py
+"""Provide an interactive REPL for sending OpenAI-compatible requests.
 
-交互式 Client 工具，用于向 Scheduler 发送 OpenAI 风格的 HTTP 请求。
+The client parses curl-like command lines, validates chat/completions or completions
+payloads, sends JSON POST requests to the Scheduler, and prints normal or streaming
+responses together with CacheRoute performance metadata.
 
-特性：
-  - 启动后进入命令行 REPL，等待用户输入一行“类 curl 命令”：
-      http://127.0.0.1:7001/v1/chat/completions -H "Content-Type: application/json" -d '{"model": "...", ...}'
-  - 支持解析：
-      * URL
-      * 多个 -H/--header 头部
-      * -d/--data/--data-raw JSON 负载
-  - 对请求做基本有效性校验（路径和 JSON payload 是否匹配 OpenAI chat/completions 或 completions）
-  - 校验通过后发送 POST 请求，并打印响应（状态码 + headers + body）
-  - 所有关键步骤都有日志输出，便于调试
+Supported input:
+  - A complete HTTP or HTTPS URL as the first argument.
+  - Multiple ``-H``/``--header`` options.
+  - A JSON body through ``-d``, ``--data``, or ``--data-raw``.
 
-注意：
-  - 当前版本默认使用 POST 方法；
-  - 仅支持 JSON 请求体，Content-Type 自动补全为 application/json。
+The client currently uses POST requests only and automatically adds
+``Content-Type: application/json`` when the header is absent.
 """
 from __future__ import annotations
 
@@ -31,7 +25,7 @@ from core.config import REQUIRED_FIELDS, ALLOWED_OPTION_FIELDS
 
 import requests
 
-# ----------------- 日志配置 -----------------
+# ----------------- Logging configuration -----------------
 logger = logging.getLogger("client")
 if not logger.handlers:
     logging.basicConfig(
@@ -39,44 +33,44 @@ if not logger.handlers:
         format="[%(asctime)s] [%(levelname)s] %(name)s - %(message)s",
     )
 
-# ----------------- 数据结构 -----------------
+# ----------------- Data structures -----------------
 @dataclass
 class ParsedRequest:
-    """解析后的请求结构"""
+    """Represent a parsed HTTP request."""
     url: str
     headers: Dict[str, str]
     body: Dict[str, Any]
 
-# ----------------- 解析逻辑 -----------------
+# ----------------- Parsing -----------------
 
 def parse_cli_line(line: str) -> ParsedRequest:
     """
-    解析一行用户输入，例如：
+    Parse one curl-like input line, for example:
       http://127.0.0.1:7001/v1/chat/completions -H "Content-Type: application/json" -d '{"model": "..."}'
 
-    支持：
-      - URL 在第一个位置
-      - -H/--header "Key: Value"
-      - -d/--data/--data-raw 'JSON字符串'
+    Supported syntax:
+      - URL in the first position.
+      - ``-H``/``--header`` with ``"Key: Value"``.
+      - ``-d``/``--data``/``--data-raw`` with a JSON string.
     """
     line = line.strip()
     if not line:
-        raise ValueError("输入为空")
+        raise ValueError("input is empty")
 
-    # 用 shlex 保留引号分组
+    # Use `shlex` to preserve quoted argument groups.
     try:
         tokens = shlex.split(line)
     except ValueError as e:
-        raise ValueError(f"命令行解析失败：{e}")
+        raise ValueError(f"failed to parse command line: {e}")
 
     if not tokens:
-        raise ValueError("解析后为空，请检查输入")
+        raise ValueError("no arguments were parsed; check the input")
 
-    # 第一个 token 必须是 URL
+    # The first token must be a complete URL.
     url = tokens[0]
     parsed = urlparse(url)
     if not parsed.scheme or not parsed.netloc:
-        raise ValueError(f"第一个参数必须是完整 URL（含 http/https），当前：{url}")
+        raise ValueError(f"the first argument must be a complete HTTP/HTTPS URL; received: {url}")
 
     headers: Dict[str, str] = {}
     body_str: Optional[str] = None
@@ -87,33 +81,33 @@ def parse_cli_line(line: str) -> ParsedRequest:
         t = tokens[i]
         if t in ("-H", "--header"):
             if i + 1 >= n:
-                raise ValueError("缺少 -H/--header 后的值，例如 -H \"Content-Type: application/json\"")
+                raise ValueError("missing value after -H/--header, for example: -H \"Content-Type: application/json\"")
             header_str = tokens[i + 1]
-            # 简单按第一个 ":" 拆分
+            # Split only on the first colon.
             if ":" not in header_str:
-                raise ValueError(f"非法 Header 格式：{header_str}，应类似于 \"Key: Value\"")
+                raise ValueError(f"invalid header format: {header_str}; expected \"Key: Value\"")
             key, value = header_str.split(":", 1)
             headers[key.strip()] = value.strip()
             i += 2
         elif t in ("-d", "--data", "--data-raw"):
             if i + 1 >= n:
-                raise ValueError("缺少 -d/--data/--data-raw 后的 JSON 字符串")
+                raise ValueError("missing JSON string after -d/--data/--data-raw")
             body_str = tokens[i + 1]
             i += 2
         else:
-            raise ValueError(f"无法识别的参数：{t}")
+            raise ValueError(f"unrecognized argument: {t}")
 
-    # body 必须存在
+    # A request body is required.
     if body_str is None:
-        raise ValueError("未提供请求体，请使用 -d/--data/--data-raw 传入 JSON 字符串")
+        raise ValueError("request body is missing; pass a JSON string with -d/--data/--data-raw")
 
-    # 解析 JSON
+    # Parse the JSON body.
     try:
         body = json.loads(body_str)
     except json.JSONDecodeError as e:
-        raise ValueError(f"请求体 JSON 解析失败：{e}")
+        raise ValueError(f"failed to parse request-body JSON: {e}")
 
-    # 补齐 Content-Type
+    # Add Content-Type when it is absent.
     ct = None
     for k in list(headers.keys()):
         if k.lower() == "content-type":
@@ -124,20 +118,19 @@ def parse_cli_line(line: str) -> ParsedRequest:
 
     return ParsedRequest(url=url, headers=headers, body=body)
 
-# ----------------- 校验逻辑 -----------------
+# ----------------- Validation -----------------
 def validate_openai_like_request(parsed: ParsedRequest) -> List[str]:
     """
-    检查 URL 路径和 JSON body 是否符合 OpenAI 风格，并做字段白名单校验。
+    Validate the URL path and JSON body against the supported OpenAI-compatible schemas.
 
-    规则：
-      - URL 路径以 /v1/chat/completions 结尾：
-          - 必须包含：model, messages
-          - 允许额外字段：ALLOWED_OPTION_FIELDS["chat"]
-      - URL 路径以 /v1/completions 结尾：
-          - 必须包含：model, prompt
-          - 允许额外字段：ALLOWED_OPTION_FIELDS["completions"]
-    返回：
-      如果 body 中出现未在“必要字段 + 允许字段”列表内的 key，视为非法字段，报错并拒绝发送请求。
+    Rules:
+      - ``/v1/chat/completions`` requires ``model`` and ``messages`` and accepts
+        fields listed in ``ALLOWED_OPTION_FIELDS["chat"]``.
+      - ``/v1/completions`` requires ``model`` and ``prompt`` and accepts fields
+        listed in ``ALLOWED_OPTION_FIELDS["completions"]``.
+
+    Unknown body keys are reported as validation errors and prevent the request
+    from being sent.
     """
     errors: List[str] = []
 
@@ -145,12 +138,12 @@ def validate_openai_like_request(parsed: ParsedRequest) -> List[str]:
     path = parsed_url.path or ""
     body = parsed.body
 
-    # 公共：model 必须存在
+    # Both endpoint types require a non-empty model name.
     model = body.get("model")
     if not isinstance(model, str) or not model:
-        errors.append("body.model 缺失或不是非空字符串")
+        errors.append("body.model is missing or is not a non-empty string")
 
-    # 判定模式
+    # Determine the endpoint mode.
     mode: Optional[str]
     if path.endswith("/v1/chat/completions"):
         mode = "chat"
@@ -159,42 +152,42 @@ def validate_openai_like_request(parsed: ParsedRequest) -> List[str]:
     else:
         mode = None
 
-    # 按模式做字段校验
+    # Validate fields for the selected endpoint mode.
     if mode is None:
-        # 未识别的路径，给个提示，但不做强字段限制
-        logger.warning("未识别的路径 %s，不进行严格字段白名单校验", path)
+        # Warn about unknown paths but do not enforce a strict field allowlist.
+        logger.warning("unrecognized path %s; strict field allowlist validation is skipped", path)
         return errors
 
-    # 必要字段检查
+    # Check required fields.
     required = REQUIRED_FIELDS.get(mode, set())
     missing = [k for k in required if k not in body]
     if missing:
         errors.append(
-            f"{mode} 请求缺少必要字段：{', '.join(missing)}"
+            f"{mode} request is missing required fields: {', '.join(missing)}"
         )
 
-    # 额外字段白名单判断
+    # Build the complete allowlist.
     allowed_options = ALLOWED_OPTION_FIELDS.get(mode, set())
     allowed_all = required | allowed_options
 
-    # body 中出现，但不在允许集合里的字段，都视为非法
+    # Treat body keys outside the allowlist as invalid.
     extra_keys = set(body.keys()) - allowed_all
     if extra_keys:
         errors.append(
-            f"{mode} 请求包含未被允许的字段：{', '.join(sorted(extra_keys))}。"
-            f" 当前仅允许：{', '.join(sorted(allowed_all))}"
+            f"{mode} request contains unsupported fields: {', '.join(sorted(extra_keys))}."
+            f" Allowed fields: {', '.join(sorted(allowed_all))}"
         )
     return errors
 
-# ----------------- 发送请求 -----------------
+# ----------------- Request sending -----------------
 
 def send_request(parsed: ParsedRequest, timeout: float = 60.0) -> requests.Response:
     """
-    使用 requests 向 Scheduler 发送 POST 请求。
+    Send a POST request to the Scheduler with ``requests``.
     """
-    logger.info("发送请求 → %s", parsed.url)
-    logger.debug("请求头: %s", parsed.headers)
-    logger.debug("请求体: %s", parsed.body)
+    logger.info("sending request -> %s", parsed.url)
+    logger.debug("request headers: %s", parsed.headers)
+    logger.debug("request body: %s", parsed.body)
 
     resp = requests.post(
         parsed.url,
@@ -205,26 +198,26 @@ def send_request(parsed: ParsedRequest, timeout: float = 60.0) -> requests.Respo
     )
     return resp
 
-# ----------------- REPL 主循环 -----------------
+# ----------------- REPL -----------------
 
 def print_help() -> None:
     msg = r"""
-用法示例（直接在 REPL 输入一行）：
+Usage examples (enter one line directly in the REPL):
 
     http://127.0.0.1:7001/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"xxx","messages":[{"role":"user","content":"Hello"}],"RAG":true,"stream":true,"Injection_type":"kvcache"}'
 
   http://127.0.0.1:7001/v1/completions -d '{"model": "xxx","prompt":"test","RAG":true,"Injection_type":"text"}'
 
-命令：
-  :help      显示本帮助
-  :quit      退出
-  :exit      退出
+Commands:
+  :help      Show this help message
+  :quit      Exit
+  :exit      Exit
 """
     print(msg)
 
 def _is_stream_requested(body: dict) -> bool:
     v = body.get("stream", False)
-    # 兼容你现在传的 "True"/"False" 字符串
+    # Accept string forms such as "True" and "False".
     if isinstance(v, str):
         return v.strip().lower() in ("1", "true", "yes", "y")
     return bool(v)
@@ -282,13 +275,10 @@ def _print_perf_summary_from_meta(meta: Dict[str, Any]) -> None:
 
 def _stream_and_print_sse(resp: requests.Response) -> None:
     """
-    解析 OpenAI 风格 SSE：
-      data: {...json...}
-      data: [DONE]
-    并将内容片段拼接为可读文本输出。
-    同时支持额外的：
-      event: cacheroute_meta
-      data: {...}
+    Parse an OpenAI-compatible SSE stream and print readable content fragments.
+
+    The parser handles standard ``data`` events, the ``[DONE]`` sentinel, and the
+    additional ``cacheroute_meta`` event emitted by CacheRoute.
     """
     print("=" * 80)
     print(f"[RESPONSE] HTTP {resp.status_code} (streaming)")
@@ -367,7 +357,7 @@ def _stream_and_print_sse(resp: requests.Response) -> None:
 
 
 def pretty_print_response(resp: requests.Response, request_body: dict) -> None:
-    """打印响应状态、头部和 body（优先按 JSON 格式化）"""
+    """Print the response status, headers, and body, preferring formatted JSON."""
     if _is_stream_requested(request_body):
         _stream_and_print_sse(resp)
         return
@@ -379,7 +369,7 @@ def pretty_print_response(resp: requests.Response, request_body: dict) -> None:
 
     print("- Body:")
     text = resp.text
-    # 尝试按 JSON 格式打印
+    # Try to format the response as JSON.
     try:
         obj = resp.json()
         print(json.dumps(obj, ensure_ascii=False, indent=2))
@@ -390,69 +380,68 @@ def pretty_print_response(resp: requests.Response, request_body: dict) -> None:
             _print_perf_summary_from_meta(meta)
 
     except ValueError:
-        # 不是合法 JSON，就原样输出
+        # Print non-JSON responses unchanged.
         print(text)
     print("=" * 80)
 
 
 def run_repl() -> None:
     """
-    交互式命令行入口：
-      - 循环读取用户输入
-      - :quit / :exit 退出
-      - :help 显示帮助
-      - 其他内容按“类 curl 命令行”解析并发送
+    Run the interactive command-line loop.
+
+    The REPL accepts ``:help``, ``:quit``, and ``:exit`` commands. Other input is
+    parsed as a curl-like request, validated, and sent to the Scheduler.
     """
     print("=== CacheRoute Client REPL ===")
-    print("输入一行 HTTP 请求（类 curl 格式），或输入 :help 查看示例，:quit 退出。")
+    print("Enter a curl-like HTTP request, use :help for examples, or :quit to exit.")
 
     while True:
         try:
             line = input("client> ").strip()
         except (EOFError, KeyboardInterrupt):
-            print("\n收到退出信号，结束。")
+            print("\nExit signal received.")
             break
 
         if not line:
             continue
 
-        # 统一处理命令，支持 :help / help / :quit / quit
+        # Normalize command aliases such as :help/help and :quit/quit.
         cmd = line.strip()
-        # 去掉前导冒号，方便统一判断
+        # Remove a leading colon before command matching.
         if cmd.startswith(":"):
             cmd = cmd[1:]
         cmd_lower = cmd.lower()
 
         if cmd_lower in ("quit", "exit"):
-            print("退出。")
+            print("Exiting.")
             break
 
         if cmd_lower in ("help", "h", "?"):
             print_help()
             continue
 
-        # 解析 + 校验 + 发送
+        # Parse, validate, and send the request.
         try:
             parsed = parse_cli_line(line)
         except ValueError as e:
-            logger.error("请求解析失败：%s", e)
+            logger.error("request parsing failed: %s", e)
             print(f"[ERROR] {e}")
             continue
 
         errors = validate_openai_like_request(parsed)
         if errors:
-            logger.error("请求校验失败：%s", "; ".join(errors))
-            print("[ERROR] 请求字段校验失败：")
+            logger.error("request validation failed: %s", "; ".join(errors))
+            print("[ERROR] Request field validation failed:")
             for msg in errors:
                 print("  -", msg)
             continue
 
-        # 发送 HTTP 请求
+        # Send the HTTP request.
         try:
             resp = send_request(parsed)
         except requests.RequestException as e:
-            logger.error("HTTP 请求失败：%s", e)
-            print(f"[ERROR] HTTP 请求异常：{e}")
+            logger.error("HTTP request failed: %s", e)
+            print(f"[ERROR] HTTP request failed: {e}")
             continue
 
         pretty_print_response(resp, parsed.body)

--- a/client/kv_timing_sender.py
+++ b/client/kv_timing_sender.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+"""Collect KVCache injection timing under an RPS-controlled workload.
+
+This benchmarking client sends workload-defined requests to the Scheduler, extracts
+CacheRoute trace metadata, estimates cache-hit and recomputation costs, optionally
+queries Scheduler knowledge lengths, and writes JSONL or CSV results.
+"""
 from __future__ import annotations
 
 import argparse
@@ -15,7 +21,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
 
-# 允许在 "python client/kv_timing_sender.py" 时导入仓库模块
+# Allow repository modules to be imported when running `python client/kv_timing_sender.py`.
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
@@ -132,7 +138,7 @@ def normalize_request_template(req_tpl: Dict[str, Any], args: argparse.Namespace
     for key in [
         "model", "stream", "RAG", "Injection_type", "max_tokens", "temperature", "top_p",
         "knowledge_id", "knowledge_ids",
-        # 允许 workload 透传长度元数据给统计器
+        # Allow workload templates to pass length metadata to the statistics collector.
         "knowledge_length_tokens", "task_length_tokens", "header_overhead_tokens", "total_length_tokens",
     ]:
         if key in req_tpl:
@@ -171,7 +177,7 @@ def _extract_knowledge_ids(body: Dict[str, Any]) -> List[str]:
     single = body.get("knowledge_id")
     if isinstance(single, str) and single.strip():
         ids.append(single.strip().lower())
-    # 去重但保持顺序
+    # Deduplicate while preserving order.
     out: List[str] = []
     seen = set()
     for k in ids:
@@ -202,7 +208,7 @@ def _resolve_knowledge_length_tokens(
         if hit > 0 and s > 0:
             return int(s), "scheduler_peek"
 
-    # 兜底：无知识长度可用时，退化到 total（会包含问题+首部）
+    # Fall back to the total length when no knowledge length is available; this includes the query and header.
     return max(0, int(total_length_tokens)), "fallback_total_length"
 
 
@@ -231,10 +237,10 @@ def build_kv_timing_record(
         if isinstance(v, list):
             meta_kids.extend([str(x).strip().lower() for x in v if str(x).strip()])
 
-    # 优先使用实际参与注入/拼接的 kid（kv_ready + text_only）。
-    # 若 meta 不可用，再退回请求体中的 knowledge_id(s)。
+    # Prefer the knowledge IDs actually used for injection or prompt construction (`kv_ready` + `text_only`).
+    # Fall back to `knowledge_id(s)` from the request body when metadata is unavailable.
     candidate_kids: List[str] = meta_kids if meta_kids else _extract_knowledge_ids(body)
-    # 去重保持顺序
+    # Deduplicate while preserving order.
     seen_kids = set()
     dedup_candidate_kids: List[str] = []
     for k in candidate_kids:
@@ -248,12 +254,12 @@ def build_kv_timing_record(
         knowledge_length_map=knowledge_length_map,
         candidate_kids=dedup_candidate_kids,
     )
-    # 防止知识长度异常大于 total_length（例如 ID 集不一致导致的累加偏大）。
+    # Prevent an inconsistent ID set from producing a knowledge length larger than `total_length`.
     knowledge_length_tokens = max(0, min(int(knowledge_length_tokens_raw), int(total_length_tokens)))
 
-    # 命中长度必须满足：
-    # 1) 256 对齐
-    # 2) 以知识长度为上限（不能超过 knowledge_length_tokens）
+    # The cache-hit length must satisfy both constraints:
+    # 1) Align to 256 tokens.
+    # 2) Do not exceed `knowledge_length_tokens`.
     aligned_hit = (knowledge_length_tokens // 256) * 256
     actual_hit_length_tokens = min(aligned_hit, knowledge_length_tokens)
     remaining_compute_tokens = max(0, total_length_tokens - actual_hit_length_tokens)
@@ -284,7 +290,7 @@ def build_kv_timing_record(
         "name": req_name,
         "http_status": status,
         "injection_type": body.get("Injection_type"),
-        # 用户要求字段
+        # Requested output fields.
         "total_length_tokens": total_length_tokens,
         "knowledge_length_tokens": knowledge_length_tokens,
         "knowledge_length_tokens_raw": knowledge_length_tokens_raw,
@@ -298,7 +304,7 @@ def build_kv_timing_record(
         "text_compute_estimate_ms": round(text_compute_estimate_ms, 3) if text_compute_estimate_ms is not None else None,
         "lmcache_redis_pull_ms": round(lmcache_redis_pull_ms, 3) if lmcache_redis_pull_ms is not None else None,
         "total_ms": total_ms,
-        # 补充关键建模字段
+        # Additional modeling fields.
         "predict_total_ms": trace.get("predict_total_ms"),
         "predict_queue_wait_ms": trace.get("predict_queue_wait_ms"),
         "predict_compute_ms": trace.get("predict_compute_ms"),
@@ -343,7 +349,7 @@ async def run_one(
     else:
         status, meta = await read_completions_meta(client, url, headers, body)
 
-    # 若开启 scheduler peek，则优先尝试用本次请求实际涉及的 kid 更新长度缓存，避免退化到 total_length
+    # When Scheduler peek is enabled, refresh the length cache with IDs used by this request to avoid falling back to `total_length`.
     if enable_scheduler_knowledge_peek and knowledge_length_map is not None:
         kids = _extract_knowledge_ids(body)
         if isinstance(meta, dict):
@@ -429,7 +435,7 @@ def write_jsonl(path: Path, rows: List[Dict[str, Any]]) -> None:
 def write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
     if not rows:
         return
-    # 扁平化 list 字段，方便 csv 消费
+    # Flatten list fields for easier CSV processing.
     normalized: List[Dict[str, Any]] = []
     for r in rows:
         item = dict(r)
@@ -465,7 +471,7 @@ async def build_knowledge_length_map(
         if isinstance(body, dict):
             kids_all.extend(_extract_knowledge_ids(body))
 
-    # 去重
+    # Deduplicate IDs.
     dedup_kids: List[str] = []
     seen = set()
     for k in kids_all:
@@ -497,8 +503,8 @@ async def build_knowledge_length_map(
             kid = str(it.get("kid", "")).strip().lower()
             if not kid:
                 continue
-            # scheduler.peek 的 length 多为“字符长度”，这里转成 token 口径
-            # 优先使用 text_abstract（kdn_sync 当前写入完整 content）分词。
+            # Scheduler peek usually reports character length, so convert it to token length here.
+            # Prefer tokenizing `text_abstract`, which currently contains the full content from `kdn_sync`.
             text_abstract = str(it.get("text_abstract") or "")
             if text_abstract:
                 try:
@@ -530,7 +536,7 @@ async def main_async(args: argparse.Namespace) -> None:
     timeout = httpx.Timeout(args.timeout_s)
     interval = 1.0 / float(args.rps)
 
-    # 与 demo_scheduler 对齐：允许在 client 进程内显式设置 tokenizer 映射，避免 HF 在线拉取。
+    # Match `demo_scheduler` by allowing an explicit tokenizer mapping in the client process and avoiding online Hugging Face downloads.
     if args.scheduler_tokenizer_map:
         os.environ["SCHEDULER_TOKENIZER_MAP"] = args.scheduler_tokenizer_map
     try:


### PR DESCRIPTION
## Summary

This draft PR starts the requested English translation pass for the uploaded client-side code.

Changed files:
- `client/client.py`
  - Rewrote the module header in English with a concise first sentence.
  - Translated Chinese docstrings, section comments, inline comments, validation messages, logger messages, REPL help text, and user-facing print output to English.
  - Kept request parsing, validation, streaming response handling, and timing-summary logic unchanged.
- `client/kv_timing_sender.py`
  - Added an English module header with a concise first sentence.
  - Translated Chinese comments around repository imports, workload length metadata, knowledge-ID ordering, fallback length logic, hit-length alignment, output fields, scheduler peek behavior, CSV flattening, tokenization, and tokenizer-map setup.
  - Kept RPS scheduling, metadata extraction, timing-record construction, JSONL/CSV output, and tokenizer behavior unchanged.

## Remaining work

`client/perf_client.py` is not included in this commit yet. I prepared a local translated version and verified it compiles, but the connector path available here cannot upload that full local file directly. The remaining intended changes are limited to:
- add an English module header with a concise first sentence;
- translate the two remaining Chinese comments in `calc_metrics()`.

## Validation

Local checks performed before publishing this draft:
- `python -m py_compile` passed for the locally translated versions of:
  - `client/client.py`
  - `client/kv_timing_sender.py`
  - `client/perf_client.py`
- Unicode scan on the local translated versions found zero remaining CJK characters.

This PR is intentionally left as a draft because `client/perf_client.py` still needs to be added to the branch before merge.