### PR TITLE
Translate client UI text to English

### DIFF
--- a/UI/client_ui/app.py
+++ b/UI/client_ui/app.py
@@ -1,3 +1,9 @@
+"""Serve the CacheRoute web client UI and bridge UI actions to client.py.
+
+This FastAPI app renders the client page, parses curl-like input through the
+existing CLI parser, validates OpenAI-style payloads, and sends requests to the
+Scheduler. It can run standalone or be mounted by another CacheRoute service.
+"""
 from __future__ import annotations
 
 import json
@@ -10,19 +16,21 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-# 复用你现有 client.py 的底层能力
+# Reuse the existing low-level capabilities from client.py.
 from client import client as client_core
 
 BASE_DIR = Path(__file__).resolve().parent          # .../UI/client_ui
 TEMPLATES_DIR = BASE_DIR / "templates"
 STATIC_DIR = BASE_DIR / "static"
 
+
 def create_client_ui_app(
     default_scheduler_url: str = "http://127.0.0.1:7001/v1/chat/completions",
     page_title: str = "CacheRoute Client UI",
 ) -> FastAPI:
     """
-    Client UI：独立 FastAPI App，可单独启动，也可被 Scheduler/Proxy mount。
+    Client UI: an independent FastAPI app that can run standalone or be mounted
+    by the Scheduler or Proxy.
     """
     app = FastAPI(title=page_title)
 
@@ -30,7 +38,7 @@ def create_client_ui_app(
 
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
-    # 静态资源
+    # Static assets.
     if not STATIC_DIR.exists():
         raise RuntimeError(f"Static directory not found: {STATIC_DIR}")
     if not TEMPLATES_DIR.exists():
@@ -52,8 +60,8 @@ def create_client_ui_app(
     @router.post("/ui/api/parse_curl")
     async def parse_curl(payload: Dict[str, Any]):
         """
-        输入：{ "line": "<curl-like line>" }
-        输出：{ url, headers, body } 或 error
+        Input: { "line": "<curl-like line>" }
+        Output: { url, headers, body } or error.
         """
         line = (payload.get("line") or "").strip()
         if not line:
@@ -67,8 +75,8 @@ def create_client_ui_app(
     @router.post("/ui/api/validate")
     async def validate_req(payload: Dict[str, Any]):
         """
-        输入：{ "url": "...", "headers": {...}, "body": {...} }
-        输出：{ ok: bool, errors: [] }
+        Input: { "url": "...", "headers": {...}, "body": {...} }
+        Output: { ok: bool, errors: [] }.
         """
         try:
             parsed = client_core.ParsedRequest(
@@ -84,21 +92,21 @@ def create_client_ui_app(
     @router.post("/ui/api/send")
     async def send_req(payload: Dict[str, Any]):
         """
-        输入：{ "url": "...", "headers": {...}, "body": {...}, "timeout": 60 }
-        输出：{ status_code, headers, body_text, body_json? }
+        Input: { "url": "...", "headers": {...}, "body": {...}, "timeout": 60 }
+        Output: { status_code, headers, body_text, body_json? }.
         """
         timeout = float(payload.get("timeout") or 60.0)
         url = str(payload.get("url") or "")
         headers = dict(payload.get("headers") or {})
         body = dict(payload.get("body") or {})
 
-        # Content-Type 补齐（和 client.py 一致的行为）
+        # Fill Content-Type in the same way as client.py.
         if not any(k.lower() == "content-type" for k in headers):
             headers["Content-Type"] = "application/json"
 
         parsed = client_core.ParsedRequest(url=url, headers=headers, body=body)
 
-        # 发送前再校验一遍，避免 UI 绕开规则
+        # Validate again before sending so the UI cannot bypass request rules.
         errors = client_core.validate_openai_like_request(parsed)
         if errors:
             return JSONResponse(status_code=400, content={"error": "validation_failed", "errors": errors})
@@ -113,7 +121,7 @@ def create_client_ui_app(
             "headers": dict(resp.headers),
             "body_text": resp.text,
         }
-        # 尝试 JSON 解析
+        # Try to parse the response as JSON.
         try:
             out["body_json"] = resp.json()
         except Exception:
@@ -131,7 +139,7 @@ def run_client_ui(
     default_scheduler_url: str,
 ) -> None:
     """
-    独立启动入口：python -m UI.client_ui.app
+    Standalone entry point: python -m UI.client_ui.app.
     """
     import uvicorn
 

--- a/UI/client_ui/static/app.js
+++ b/UI/client_ui/static/app.js
@@ -72,23 +72,23 @@ $("mode").addEventListener("change", () => {
   loadExample();
 });
 
-// 初始加载示例
+// Load the initial example.
 loadExample();
 
 $("btn-parse-curl").addEventListener("click", async () => {
   const line = $("curlLine").value.trim();
-  if (!line) { $("curlParseMsg").textContent = "请输入一行命令"; return; }
+  if (!line) { $("curlParseMsg").textContent = "Please enter one command line"; return; }
 
   const res = await apiPost("/ui/api/parse_curl", { line });
   if (!res.ok) {
-    $("curlParseMsg").textContent = "解析失败：" + (res.data.error || "unknown");
+    $("curlParseMsg").textContent = "Parse failed: " + (res.data.error || "unknown");
     return;
   }
   const p = res.data.parsed;
   $("url").value = p.url || "";
   $("headers").value = pretty(p.headers || {});
   $("body").value = pretty(p.body || {});
-  $("curlParseMsg").textContent = "解析成功：已填充到表单";
+  $("curlParseMsg").textContent = "Parsed successfully: populated the form";
 });
 
 $("btn-validate").addEventListener("click", async () => {
@@ -97,17 +97,17 @@ $("btn-validate").addEventListener("click", async () => {
   const bodyText = $("body").value.trim();
 
   const hdr = safeJsonParse(hdrText);
-  if (!hdr.ok) { showValidation(false, "Headers JSON 解析失败：" + hdr.err); return; }
+  if (!hdr.ok) { showValidation(false, "Headers JSON parse failed: " + hdr.err); return; }
   const body = safeJsonParse(bodyText);
-  if (!body.ok) { showValidation(false, "Body JSON 解析失败：" + body.err); return; }
+  if (!body.ok) { showValidation(false, "Body JSON parse failed: " + body.err); return; }
 
   const res = await apiPost("/ui/api/validate", { url, headers: hdr.val, body: body.val });
   if (!res.ok) {
-    showValidation(false, "校验接口异常：" + pretty(res.data));
+    showValidation(false, "Validation API error: " + pretty(res.data));
     return;
   }
-  if (res.data.ok) showValidation(true, "校验通过 ✅");
-  else showValidation(false, "校验失败：\n" + (res.data.errors || []).join("\n"));
+  if (res.data.ok) showValidation(true, "Validation passed ✅");
+  else showValidation(false, "Validation failed:\n" + (res.data.errors || []).join("\n"));
 });
 
 $("btn-send").addEventListener("click", async () => {
@@ -118,11 +118,11 @@ $("btn-send").addEventListener("click", async () => {
   const bodyText = $("body").value.trim();
 
   const hdr = safeJsonParse(hdrText);
-  if (!hdr.ok) { showValidation(false, "Headers JSON 解析失败：" + hdr.err); return; }
+  if (!hdr.ok) { showValidation(false, "Headers JSON parse failed: " + hdr.err); return; }
   const body = safeJsonParse(bodyText);
-  if (!body.ok) { showValidation(false, "Body JSON 解析失败：" + body.err); return; }
+  if (!body.ok) { showValidation(false, "Body JSON parse failed: " + body.err); return; }
 
-  showValidation(true, "发送中...");
+  showValidation(true, "Sending...");
 
   const res = await apiPost("/ui/api/send", {
     url,
@@ -133,9 +133,9 @@ $("btn-send").addEventListener("click", async () => {
 
   if (!res.ok) {
     if (res.data && res.data.error === "validation_failed") {
-      showValidation(false, "发送前校验失败：\n" + (res.data.errors || []).join("\n"));
+      showValidation(false, "Pre-send validation failed:\n" + (res.data.errors || []).join("\n"));
     } else {
-      showValidation(false, "发送失败：" + pretty(res.data));
+      showValidation(false, "Send failed: " + pretty(res.data));
     }
     return;
   }
@@ -146,5 +146,5 @@ $("btn-send").addEventListener("click", async () => {
   const bodyTextResp = bodyJson ? pretty(bodyJson) : (res.data.body_text || "");
 
   setResponse(`HTTP ${status}`, headersObj, bodyTextResp);
-  showValidation(true, "请求完成 ✅");
+  showValidation(true, "Request completed ✅");
 });

--- a/UI/client_ui/templates/index.html
+++ b/UI/client_ui/templates/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -17,7 +17,7 @@
     <div class="flex items-center justify-between mb-6">
       <div>
         <h1 class="text-2xl font-semibold tracking-tight">🛰️ CacheRoute Client UI</h1>
-        <p class="text-slate-400 mt-1">向 Scheduler 发送 OpenAI 风格请求，并展示校验与响应结果</p>
+        <p class="text-slate-400 mt-1">Send OpenAI-style requests to the Scheduler and display validation and response results.</p>
       </div>
       <div class="text-sm text-slate-400">
         <span class="px-3 py-1 rounded-full bg-slate-900 border border-slate-800">UI / Client</span>
@@ -30,14 +30,14 @@
       <div class="col-span-12 lg:col-span-7">
         <div class="card">
           <div class="card-hd">
-            <div class="font-medium">请求编辑</div>
-            <div class="text-xs text-slate-400">支持 chat/completions 与 completions</div>
+            <div class="font-medium">Request Editor</div>
+            <div class="text-xs text-slate-400">Supports chat/completions and completions</div>
           </div>
 
           <div class="card-bd space-y-4">
             <div class="grid grid-cols-2 gap-3">
               <div>
-                <label class="label">模式</label>
+                <label class="label">Mode</label>
                 <select id="mode" class="input">
                   <option value="chat">chat/completions</option>
                   <option value="completions">completions</option>
@@ -62,14 +62,14 @@
             <div>
               <div class="flex items-center justify-between">
                 <label class="label">Body (JSON)</label>
-                <button id="btn-load-example" class="btn btn-ghost">加载示例</button>
+                <button id="btn-load-example" class="btn btn-ghost">Load Example</button>
               </div>
               <textarea id="body" class="textarea font-mono" rows="12"></textarea>
             </div>
 
             <div class="flex gap-3">
-              <button id="btn-validate" class="btn btn-secondary">校验</button>
-              <button id="btn-send" class="btn btn-primary">发送请求</button>
+              <button id="btn-validate" class="btn btn-secondary">Validate</button>
+              <button id="btn-send" class="btn btn-primary">Send Request</button>
             </div>
 
             <div id="validation" class="hidden"></div>
@@ -78,13 +78,13 @@
 
         <div class="card mt-6">
           <div class="card-hd">
-            <div class="font-medium">类 curl 一行命令</div>
-            <div class="text-xs text-slate-400">粘贴后解析到表单（复用 client.parse_cli_line）</div>
+            <div class="font-medium">Curl-like One-line Command</div>
+            <div class="text-xs text-slate-400">Paste a command and parse it into the form by reusing client.parse_cli_line.</div>
           </div>
           <div class="card-bd space-y-3">
             <textarea id="curlLine" class="textarea font-mono" rows="4"
               placeholder='http://127.0.0.1:7001/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"...\",\"messages\":[...]}"'></textarea>
-            <button id="btn-parse-curl" class="btn btn-ghost">解析</button>
+            <button id="btn-parse-curl" class="btn btn-ghost">Parse</button>
             <div id="curlParseMsg" class="text-sm text-slate-400"></div>
           </div>
         </div>
@@ -94,11 +94,11 @@
       <div class="col-span-12 lg:col-span-5">
         <div class="card">
           <div class="card-hd">
-            <div class="font-medium">响应</div>
-            <div class="text-xs text-slate-400">状态码 / headers / body</div>
+            <div class="font-medium">Response</div>
+            <div class="text-xs text-slate-400">Status code / headers / body</div>
           </div>
           <div class="card-bd space-y-3">
-            <div id="respMeta" class="text-sm text-slate-400">尚未发送请求</div>
+            <div id="respMeta" class="text-sm text-slate-400">No request sent yet</div>
 
             <div>
               <div class="label">Headers</div>
@@ -114,12 +114,12 @@
 
         <div class="card mt-6">
           <div class="card-hd">
-            <div class="font-medium">提示</div>
-            <div class="text-xs text-slate-400">字段白名单由 client.py 控制</div>
+            <div class="font-medium">Tips</div>
+            <div class="text-xs text-slate-400">The field allowlist is controlled by client.py</div>
           </div>
           <div class="card-bd text-sm text-slate-300 space-y-2">
-            <div>• UI 不绕开校验：发送前会再次调用 validate_openai_like_request。</div>
-            <div>• 如果你扩展允许字段，只需要更新 core.config 的 ALLOWED_OPTION_FIELDS。</div>
+            <div>• The UI does not bypass validation: it calls validate_openai_like_request again before sending.</div>
+            <div>• To extend allowed fields, update ALLOWED_OPTION_FIELDS in core.config.</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Translate CacheRoute client UI Python comments/docstrings to English.
- Translate browser-side UI messages and validation text in app.js to English.
- Translate the client UI HTML page text to English and set the page language to English.

## Validation
- Locally compiled the updated app.py with py_compile.
- Scanned the three updated files for remaining Chinese characters; none were found.
- Checked the branch diff against main: only UI/client_ui/app.py, UI/client_ui/static/app.js, and UI/client_ui/templates/index.html changed.

style.css was inspected and left unchanged because it only contains styles.