### PR TITLE
Enrich predictor README documentation

### DIFF
--- a/instance/TPOT_predictor/README.md
+++ b/instance/TPOT_predictor/README.md
@@ -1,165 +1,320 @@
 # TPOT Predictor
 
-`TPOT_predictor` 用于采集并输出按真实 `sequence_length` 组织的 TPOT 曲线，支持区间接口、异常值剔除、平滑诊断、四项线性拟合和 decode 预测。
+`TPOT_predictor` measures and models TPOT (Time Per Output Token) for vLLM-style streaming generation.
+
+This module is designed for CacheRoute experiments that need decode-time estimates by **real `sequence_length`**, not just by the synthetic prompt length used to generate benchmark requests. It can collect TPOT curves, remove outliers, smooth low-confidence points, fit a four-term decode model, compare baseline and prefill-loaded scenarios, and export length-wise results for later scheduling analysis.
 
 ---
 
-## 1. TPOT 时间戳定义
+## 1. What this predictor measures
 
-当前 TPOT 捕获是基于**客户端流式接收时间戳**：
+TPOT is measured from client-side streaming token arrivals:
 
-- 在 `send_stream_request_for_tpot(...)` 里使用 `time.perf_counter()` 记录 token 事件到达时间。
-- 第一个生成 token 的时间差记为 TTFT。
-- 后续 token 的时间差记为 TPOT step delta。
+- `send_stream_request_for_tpot(...)` records token-event arrival timestamps with `time.perf_counter()`.
+- The delay from request dispatch to the first generated token is treated as TTFT.
+- The interval between later generated-token events is treated as the TPOT step delta.
 
-这意味着 TPOT 包含了：服务端 decode + 流式刷出节奏 + 网络传输抖动 + 客户端事件循环调度抖动。
+Because the measurement boundary is the client stream receiver, TPOT includes more than pure GPU decode time:
 
----
+- server-side decode execution,
+- vLLM streaming flush behavior,
+- SSE chunk aggregation,
+- network jitter,
+- and local event-loop scheduling jitter.
 
-## 2. 为什么会出现偶发尖峰
-
-流式测量中尖峰常见来源：
-
-1. 多 token 被同一 SSE event 聚合后一起到达；
-2. 网络短时抖动导致 chunk 堆积后突发到达；
-3. 客户端调度抖动（event loop 被其他任务占用）；
-4. 某些 `(bs, sequence_length)` 桶样本太少，单点异常难以被桶内统计抵消。
+For this reason, the exported TPOT curve should be interpreted as an end-to-end decode-token service curve under the current deployment, not as a hardware-only kernel benchmark.
 
 ---
 
-## 3. 新增稳健处理（本次重点）
+## 2. Key files
 
-### 3.1 默认统计口径
-
-默认用于拟合/预测的列从 `filtered_mean_tpot_ms` 切换为更稳健的：
-
-- `filtered_median_tpot_ms`（优先）
-
-并保留均值列作为参考。
-
-### 3.2 平滑列
-
-每个 bs 内，按 sequence_length 顺序新增滑动中位数平滑：
-
-- `smoothed_tpot_ms`
-
-平滑不会覆盖原始值，只是额外诊断列。
-
-### 3.3 双层异常保护
-
-每个点新增：
-
-- `is_low_confidence`：`filtered_samples < min_samples_for_filter`
-- `suspicious_spike`：低置信点且相对邻域出现突增
-
-### 3.4 default_tpot_ms 规则
-
-每个点新增：
-
-- `default_tpot_ms`
-
-优先级：
-
-1. `filtered_median_tpot_ms`
-2. `smoothed_tpot_ms`
-3. `filtered_mean_tpot_ms`
+| File | Role |
+| --- | --- |
+| `tpot_predictor.py` | High-level orchestration APIs for collection, range curves, fitting, prediction, scenario comparison, and exports. |
+| `tpot_regressor.py` | Stores observations, applies outlier filtering and smoothing, builds length-wise curves, fits the four-term model, and predicts decode time. |
+| `request_generator.py` | Builds tokenizer-controlled prompts and sends streaming requests to the target vLLM service. |
+| `local_test.py` | Local helpers for ad-hoc measurement and debugging. |
+| `output/` | Recommended location for generated JSON, CSV, and XLSX artifacts. |
 
 ---
 
-## 4. 新区间接口（核心）
+## 3. Default benchmark configuration
+
+The default vLLM target is defined in `tpot_predictor.py`:
 
 ```python
-collect_tpot_range(
-    batch_sizes: List[int],
-    length_start: int,
-    length_end: int,
-    ...
+VLLM_CONFIG_DEFAULT = {
+    "host": "0.0.0.0",
+    "port": 8000,
+    "model_id": "llama3-70b",
+    "tokenizer_path": "/workspace/llm-stack/models/LLM-Research/Meta-Llama-3-70B-Instruct/",
+}
+```
+
+The default test grid is:
+
+```python
+BATCH_SIZES_TO_TEST = range(1, 9)
+TOKEN_LENGTHS_TO_TEST = [
+    *range(8, 128, 8),
+    *range(128, 512, 32),
+    *range(512, 2048, 64),
+]
+```
+
+`WARM_UP_CONFIGS_DEFAULT` keeps only configurations with `batch_size * prompt_length <= 10000` to avoid excessively large benchmark requests.
+
+Adjust these defaults before using the predictor on a different model, tokenizer path, host, port, or GPU capacity.
+
+---
+
+## 4. Sequence length semantics
+
+Most public APIs in this directory use **real `sequence_length`** as the user-facing length.
+
+Internally, prompt generation still uses `target_prompt_length`. The predictor estimates the chat-template offset through the tokenizer and maps the requested real sequence-length interval to the prompt lengths that should be tested.
+
+This distinction matters because TPOT during decode depends on the actual KV length seen by the model:
+
+```text
+sequence_length = real prompt tokens already in context + generated tokens so far
+```
+
+When using the range APIs, `length_start` and `length_end` always refer to this real sequence-length interval.
+
+---
+
+## 5. Main collection modes
+
+### 5.1 Matrix collection
+
+Use `collect_tpot_matrix(...)` when you already know the exact `(batch_size, target_prompt_length)` configurations to test:
+
+```python
+regressor = await collect_tpot_matrix(
+    configs=[(1, 128), (1, 256), (2, 128)],
+    max_tokens=16,
+    repeats=3,
+    concurrency=None,
 )
 ```
 
-这里的 `length_start/length_end` 语义是：**真实 sequence_length 区间 [a,b]**。
+This mode is useful for controlled warmup grids and low-level regression debugging.
 
-接口会自动：
+### 5.2 Range collection by real sequence length
 
-1. 把区间映射成内部待测 `target_prompt_length` 配置；
-2. 输出 `sequence_length=a..b` 的连续曲线；
-3. 对每个点标记来源：`observed / interpolated / fitted / none`。
-
-### 4.1 连续长度采样主模式（推荐）
+Use `collect_tpot_range(...)` when the scheduler or experiment logic needs a continuous curve over a real sequence-length interval:
 
 ```python
-collect_continuous_tpot_curve(
+result = await collect_tpot_range(
+    batch_sizes=[1, 2, 4],
+    length_start=128,
+    length_end=512,
+    max_tokens=16,
+    repeats=3,
+    fit_after_collect=True,
+)
+```
+
+The returned dictionary includes:
+
+- `requested`: the user-facing range and batch sizes,
+- `planned_test_configs`: the internally generated `(batch_size, target_prompt_length)` tests,
+- `fit_coefficients`: the fitted four-term model coefficients when fitting succeeds,
+- `range_curve`: the final length-wise rows,
+- `summary`: aggregate benchmark diagnostics,
+- `regressor`: the live `TPOTRegressor` instance.
+
+### 5.3 Continuous curve collection for one batch size
+
+Use `collect_continuous_tpot_curve(...)` when you want one request to cover several adjacent decode positions and then tile the requested interval with overlapping windows:
+
+```python
+result = await collect_continuous_tpot_curve(
     batch_size=1,
     real_input_length=128,
     length_start=128,
     length_end=256,
     max_tokens=32,
     repeats=3,
+    overlap_tokens=4,
+    fit_after_collect=True,
 )
 ```
 
-思路是固定一个 real_input_length 起点，单请求直接覆盖一段连续长度：
+This mode is usually the most convenient way to build smooth per-length curves because each streaming request contributes TPOT observations for:
 
-- 一次请求覆盖 `sequence_length = L0, L0+1, ..., L0+max_tokens-1`
-- 多个起点窗口按 stride 规划并允许重叠（`overlap_tokens`），让 `[a,b]` 覆盖更完整。
-
----
-
-## 5. 导出字段（csv/json/xlsx）
-
-导出列：
-
-- `batch_size`
-- `sequence_length`
-- `raw_samples`
-- `filtered_samples`
-- `raw_mean_tpot_ms`
-- `filtered_mean_tpot_ms`
-- `filtered_median_tpot_ms`
-- `filtered_p95_tpot_ms`
-- `outlier_count`
-- `is_low_confidence`
-- `suspicious_spike`
-- `smoothed_tpot_ms`
-- `default_tpot_ms`
-- `value_source`
-
-支持 `.xlsx`，若环境无 `openpyxl` 自动回退 `.csv`。
-
----
-
-## 6. summarize 区间查看
-
-```python
-summarize_results(summary, full_curve_bs=1, length_range=(a,b))
+```text
+sequence_length = L0, L0 + 1, ..., L0 + max_tokens - 1
 ```
 
-会打印：
-
-- `raw_samples / filtered_samples / outlier_count`
-- `is_low_confidence / suspicious_spike`
-- `filtered_median_tpot_ms / smoothed_tpot_ms / default_tpot_ms`
-
-并且可以用覆盖诊断函数：
-
-```python
-check_length_coverage(regressor, batch_size=1, length_start=a, length_end=b)
-```
-
-返回：
-
-- `covered_lengths`
-- `missing_lengths`
-- `coverage_ratio`
-- `max_gap`
+Overlapping windows reduce missing points and make interpolation less fragile.
 
 ---
 
-## 7. 最小调用样例
+## 6. Robust statistics and diagnostics
+
+Streaming TPOT data often contains spikes. Common causes include SSE event aggregation, short network stalls, client event-loop scheduling delay, and low sample counts for individual `(batch_size, sequence_length)` buckets.
+
+The predictor keeps several diagnostic columns instead of hiding this uncertainty:
+
+| Column | Meaning |
+| --- | --- |
+| `raw_samples` | Number of raw TPOT deltas collected for this length. |
+| `filtered_samples` | Number of samples left after outlier filtering. |
+| `raw_mean_tpot_ms` | Mean TPOT before filtering. |
+| `filtered_mean_tpot_ms` | Mean TPOT after filtering. |
+| `filtered_median_tpot_ms` | Median TPOT after filtering; preferred as the default stable statistic. |
+| `filtered_p95_tpot_ms` | P95 TPOT after filtering. |
+| `outlier_count` | Number of samples removed by the filter. |
+| `is_low_confidence` | Whether the point has fewer samples than `min_samples_for_filter`. |
+| `suspicious_spike` | Whether a low-confidence point is unusually high relative to neighbors. |
+| `smoothed_tpot_ms` | Sliding-median smoothing result within the same batch size. |
+| `default_tpot_ms` | Main value used for fitting and prediction. |
+| `value_source` | `observed`, `interpolated`, `fitted`, or `none`. |
+
+By default, `default_tpot_ms` is selected in this priority order:
+
+1. `filtered_median_tpot_ms`,
+2. `smoothed_tpot_ms`,
+3. `filtered_mean_tpot_ms`.
+
+This policy keeps the raw and filtered values visible while making downstream fitting less sensitive to one-off spikes.
+
+---
+
+## 7. Four-term decode fitting and prediction
+
+After collection, the predictor can fit a four-term regression model over the length-wise curve:
+
+```python
+coeffs = fit_tpot_four_term(regressor, label_key="default_tpot_ms")
+```
+
+The high-level range APIs can also fit automatically with `fit_after_collect=True`.
+
+To estimate the total decode time for a future request, use:
+
+```python
+prediction = predict_decode_time(
+    regressor=regressor,
+    batch_size=1,
+    start_sequence_length=128,
+    max_tokens=32,
+    prefer_fitted=True,
+    label_key="default_tpot_ms",
+)
+```
+
+The return value comes from `TPOTRegressor.predict_decode_time_ms(...)` and is intended to support scheduling-level estimates of how long the decode phase will occupy the instance.
+
+---
+
+## 8. Coverage inspection
+
+Use `summarize_results(...)` for a readable text summary:
+
+```python
+print(summarize_results(summary, full_curve_bs=1, length_range=(128, 192)))
+```
+
+Use `check_length_coverage(...)` to verify whether a range is fully covered:
+
+```python
+coverage = check_length_coverage(
+    regressor,
+    batch_size=1,
+    length_start=128,
+    length_end=192,
+)
+```
+
+Typical fields include:
+
+- `covered_lengths`,
+- `missing_lengths`,
+- `coverage_ratio`,
+- `max_gap`.
+
+If the coverage ratio is low, increase `max_tokens`, increase overlap, add more starting windows, or use a denser collection range.
+
+---
+
+## 9. Export formats
+
+The regressor can export JSON and length-wise curves:
+
+```python
+regressor.export_json("instance/TPOT_predictor/output/tpot_results.json")
+regressor.export_lengthwise_curve(
+    "instance/TPOT_predictor/output/tpot_length_curve.csv",
+    rows=result["range_curve"],
+)
+```
+
+Supported curve file extensions include `.csv`, `.json`, and `.xlsx`. If `.xlsx` is requested but `openpyxl` is not installed, the implementation falls back to CSV.
+
+Recommended export naming pattern:
+
+```text
+output/{scenario}_bs{batch_size}_{length_start}_{length_end}.{csv|json|xlsx}
+```
+
+---
+
+## 10. Prefill-load interference experiments
+
+The TPOT predictor can compare decode behavior in two scenarios:
+
+- `baseline`: normal TPOT collection,
+- `with_prefill_load`: TPOT collection while background prefill-style requests are sent.
+
+The prefill load is approximated with long prompts and `max_tokens=1`:
+
+```python
+loaded = await collect_continuous_tpot_curve(
+    batch_size=1,
+    real_input_length=33,
+    length_start=33,
+    length_end=256,
+    repeats=1,
+    max_tokens=32,
+    with_prefill_load=True,
+    prefill_prompt_length=1024,
+    prefill_concurrency=1,
+    prefill_interval_ms=0,
+    prefill_max_tokens=1,
+)
+```
+
+This does not represent a strict prefill-only primitive, because the OpenAI-compatible chat/completions API usually still produces at least one token. It is best interpreted as a practical interference workload for studying decode latency under prefill pressure.
+
+Compare scenarios with:
+
+```python
+compare_rows = compare_tpot_between_scenarios(
+    regressor=loaded["regressor"],
+    batch_size=1,
+    length_start=33,
+    length_end=256,
+    value_key="default_tpot_ms",
+)
+
+export_scenario_compare(
+    regressor=loaded["regressor"],
+    output_path="instance/TPOT_predictor/output/compare_bs1_33_256.csv",
+    rows=compare_rows,
+)
+```
+
+---
+
+## 11. Minimal end-to-end example
 
 ```python
 import asyncio
 from tpot_predictor import collect_continuous_tpot_curve, summarize_results
+
 
 async def main():
     result = await collect_continuous_tpot_curve(
@@ -180,88 +335,26 @@ async def main():
     summary = result["summary"]
     print(summarize_results(summary, full_curve_bs=1, length_range=(128, 192)))
 
-    reg = result["regressor"]
-    reg.export_lengthwise_curve(
+    regressor = result["regressor"]
+    regressor.export_lengthwise_curve(
         "instance/TPOT_predictor/output/range_128_192_bs1.xlsx",
         rows=result["range_curve"],
     )
 
+
 asyncio.run(main())
 ```
+
+Run it from the repository root or make sure this directory is on `PYTHONPATH` so that local imports such as `request_generator` and `tpot_regressor` resolve correctly.
 
 ---
 
-## 8. Prefill 干扰模式（新增）
+## 12. Practical tuning advice
 
-新增目标：在采集 decode TPOT 时，后台持续注入 Prefill 型干扰请求，比较：
-
-- `scenario=baseline`
-- `scenario=with_prefill_load`
-
-实现方式是近似模拟：
-
-- 使用“长 prompt + `max_tokens=1`”来制造 Prefill 计算占用；
-- 不追求严格 prefill-only（chat/completions 下通常不可直接表达纯 prefill）。
-
-### 8.1 最小实验（你给的参数）
-
-```python
-import asyncio
-from tpot_predictor import (
-    collect_continuous_tpot_curve,
-    compare_tpot_between_scenarios,
-    export_scenario_compare,
-)
-
-async def main():
-    # baseline
-    baseline = await collect_continuous_tpot_curve(
-        batch_size=1,
-        real_input_length=33,
-        length_start=33,
-        length_end=256,
-        repeats=1,
-        max_tokens=32,
-        with_prefill_load=False,
-    )
-    reg = baseline["regressor"]
-    reg.export_lengthwise_curve(
-        "instance/TPOT_predictor/output/baseline_bs1_33_256.csv",
-        rows=baseline["range_curve"],
-    )
-
-    # with prefill load
-    loaded = await collect_continuous_tpot_curve(
-        batch_size=1,
-        real_input_length=33,
-        length_start=33,
-        length_end=256,
-        repeats=1,
-        max_tokens=32,
-        with_prefill_load=True,
-        prefill_prompt_length=1024,
-        prefill_concurrency=1,
-        prefill_interval_ms=0,
-        prefill_max_tokens=1,
-    )
-    reg2 = loaded["regressor"]
-    reg2.export_lengthwise_curve(
-        "instance/TPOT_predictor/output/prefill_loaded_bs1_33_256.csv",
-        rows=loaded["range_curve"],
-    )
-
-    compare_rows = compare_tpot_between_scenarios(
-        regressor=reg2,
-        batch_size=1,
-        length_start=33,
-        length_end=256,
-        value_key="default_tpot_ms",
-    )
-    export_scenario_compare(
-        regressor=reg2,
-        output_path="instance/TPOT_predictor/output/compare_bs1_33_256.csv",
-        rows=compare_rows,
-    )
-
-asyncio.run(main())
-```
+- Increase `repeats` when individual length buckets have too few samples.
+- Increase `max_tokens` when you want each request to cover a longer sequence-length window.
+- Increase `overlap_tokens` when you want smoother continuity between windows.
+- Keep `prefer_fitted=True` when the curve has missing points and the fitted model is stable.
+- Use `prefer_fitted=False` when you want to inspect observed and interpolated values without model substitution.
+- Treat `suspicious_spike=True` points as diagnostics before using them for scheduler tuning.
+- Recollect curves when changing model, GPU, tensor parallelism, vLLM version, scheduler policy, or background load.

--- a/instance/TTFT_predictor/README.md
+++ b/instance/TTFT_predictor/README.md
@@ -1,225 +1,368 @@
 # TTFT Predictor
 
-`TTFT_predictor` 用于估计和在线校准 LLM 请求的 `TTFT`（Time To First Token，首 token 延迟）。
+`TTFT_predictor` estimates and continuously calibrates TTFT (Time To First Token) for LLM requests.
 
-这个目录里的代码主要面向两类场景：
+In CacheRoute, TTFT is mainly used as a scheduler-side approximation of the prefill stage. The predictor provides a fast regression model for online decisions, plus warmup and feedback paths that let the model adapt to the actual vLLM deployment.
 
-1. 在调度器里快速预测在给定 `batch_size` 和 `prompt_length` 下的 TTFT。
-2. 通过真实请求对预测模型做 warmup 和在线数据回流更新。
+---
 
-当前实现：
+## 1. What this component is for
 
-- `prefill_regressor.py` + `prefill_predictor.py` + `prefill_prediction_server.py`
+This directory targets two related scenarios:
 
+1. **Fast prediction before scheduling**: estimate TTFT for a request with a given `batch_size` and `prompt_length`.
+2. **Online calibration after execution**: feed measured prefill or first-token latency back into the model so predictions track the real system.
 
-## 目录结构
+The implementation is intentionally lightweight. It favors a small linear model that can be called frequently by the scheduler over a heavy model that would add prediction latency.
 
-- `[prefill_regressor.py]`：线性回归器，负责收集训练数据、拟合模型、发起 warmup 请求和执行预测。
-- `[prefill_predictor.py]`：对外提供异步接口，管理单例回归器，支持预测、数据回流和详细 warmup。
-- `[prefill_prediction_server.py]`：FastAPI 服务，对外暴露 HTTP 接口。
-- `[request_generator.py]`：根据目标 token 数生成 prompt，并向 vLLM 发送测试请求。
-- `[local_test.py]`：本地测量 TTFT 的辅助函数。
+---
 
-## 核心思路
+## 2. Key files
 
-模型使用一个简单的线性特征组合来拟合 TTFT：
+| File | Role |
+| --- | --- |
+| `prefill_regressor.py` | Owns the regression model, stores training samples, triggers warmup requests, fits coefficients, and predicts TTFT. |
+| `prefill_predictor.py` | Async singleton facade used by Python callers; exposes prediction, feedback update, and detailed warmup APIs. |
+| `prefill_prediction_server.py` | FastAPI service exposing `/predict` and `/report_prefill` for out-of-process scheduler integration. |
+| `request_generator.py` | Generates tokenizer-controlled prompts and sends measurement requests to vLLM. |
+| `local_test.py` | Local helpers for direct TTFT measurement and debugging. |
+| `WORKFLOW.md` | Additional call-flow notes for startup, warmup, prediction, and reporting paths. |
 
-`TTFT ~= a * (batch_size * prompt_length) + b * prompt_length + c * batch_size + d`
+---
 
-其中：
+## 3. Regression model
 
-- `batch_size * prompt_length` 反映 prefill 计算量
-- `prompt_length` 反映单请求上下文长度
-- `batch_size` 反映批大小本身带来的调度/排队影响
+The predictor fits TTFT with a simple feature set:
 
-这一近似模型的优点是：
-
-- 推理非常快，适合调度器实时调用
-- 易于通过在线采样持续校准
-- 很适合做 warmup 后的近似预测
-
-## 工作流程文档
-
-函数调用关系、服务启动链路、后台预热线路、`/predict` 与 `/report_prefill` 的触发路径，已经单独整理在：
-
-`[WORKFLOW.md]`
-
-## 依赖
-
-建议的 Python 依赖至少包括：
-
-```bash
-pip install numpy aiohttp scikit-learn transformers fastapi uvicorn pydantic
+```text
+TTFT ~= a * (batch_size * prompt_length) + b * prompt_length + c * batch_size + d
 ```
 
-如果你在 Linux 服务器上运行，还需要保证：
+The terms have the following interpretation:
 
-- 可以访问目标 vLLM 服务
-- `tokenizer_path` 对应模型的 tokenizer 可加载
+| Term | Meaning |
+| --- | --- |
+| `batch_size * prompt_length` | Approximate total prefill work in the batch. |
+| `prompt_length` | Per-request context length. |
+| `batch_size` | Batch-size overhead and scheduling effects. |
+| `d` | Intercept for fixed overhead. |
 
-## 使用方式
+The implementation normalizes features with `StandardScaler`, fits a `LinearRegression`, and then de-normalizes the coefficients into `a`, `b`, `c`, and `d` for inspection.
 
-### 方式 1：作为 Python 模块直接调用
+This model is only an approximation. It is most useful after warmup on the same model, hardware, vLLM configuration, and request path that will be used in production experiments.
 
-最常用的接口在 `[prefill_predictor.py]`。
+---
 
-可用接口：
+## 4. Default configuration
 
-- `predict_ttft(batch_size, prompt_length)`：预测 TTFT，返回秒
-- `update_prefill_data(batch_size, prompt_length, prefill_time)`：上报真实 prefill 时间
-- `perform_detailed_warmup(...)`：执行真实 warmup 和模型拟合
+The default vLLM target is defined in `prefill_predictor.py`:
 
-示例：
+```python
+VLLM_CONFIG_DEFAULT = {
+    "host": "0.0.0.0",
+    "port": 8000,
+    "model_id": "llama3-70b",
+    "tokenizer_path": "/workspace/llm-stack/models/LLM-Research/Meta-Llama-3-70B-Instruct/",
+    "batch_sample_policy": "mid_minmax",
+}
+```
+
+The warmup grid is:
+
+```python
+BATCH_SIZES_TO_TEST = range(1, 9)
+TOKEN_LENGTHS_TO_TEST = range(64, 2048, 64)
+```
+
+`WARM_UP_CONFIGS_DEFAULT` keeps only configurations with `batch_size * prompt_length <= 10000`.
+
+Before running on a new server, verify at least:
+
+- `host` and `port` point to the target vLLM service,
+- `model_id` matches the model served by vLLM,
+- `tokenizer_path` can be loaded locally,
+- the warmup grid fits the GPU memory and expected serving range.
+
+---
+
+## 5. Python module usage
+
+The main Python facade is `prefill_predictor.py`.
+
+### 5.1 Predict TTFT
 
 ```python
 import asyncio
-from prefill_predictor import predict_ttft, update_prefill_data
+from prefill_predictor import predict_ttft
+
 
 async def main():
-    pred = await predict_ttft(batch_size=4, prompt_length=1024)
-    print(f"predicted ttft = {pred:.4f}s")
+    prediction = await predict_ttft(batch_size=4, prompt_length=1024)
+    print(f"predicted_ttft = {prediction:.4f}s")
 
-    await update_prefill_data(
-        batch_size=4,
-        prompt_length=1024,
-        prefill_time=0.185
-    )
 
 asyncio.run(main())
 ```
 
-说明：
+`predict_ttft(...)` returns seconds. If the model has not been fitted yet, it falls back to a simple cold-start estimate.
 
-- 第一次调用 `predict_ttft` 时会初始化回归器
-- 如果还没有真实 warmup 数据，会先用少量 dummy data 启动
-- 后续可以持续调用 `update_prefill_data` 做在线校准
+### 5.2 Report measured data
 
-### 方式 2：启动 HTTP 预测服务
+```python
+import asyncio
+from prefill_predictor import update_prefill_data
 
-如果你希望调度器通过 HTTP 调用预测服务，直接运行：
+
+async def main():
+    await update_prefill_data(
+        batch_size=4,
+        prompt_length=1024,
+        prefill_time=0.185,
+    )
+
+
+asyncio.run(main())
+```
+
+`update_prefill_data(...)` appends one training sample to the in-memory regressor. The current validation filters out invalid or extreme values below `0.001s` or above `60s`.
+
+### 5.3 Run detailed warmup
+
+```python
+import asyncio
+from prefill_predictor import perform_detailed_warmup
+
+
+async def main():
+    await perform_detailed_warmup(repeats=3)
+
+
+asyncio.run(main())
+```
+
+Detailed warmup clears existing training data, tests each `(batch_size, prompt_length)` configuration, collects repeated measurements, and fits the model once all configurations finish.
+
+---
+
+## 6. HTTP prediction service
+
+Run the FastAPI service from the predictor directory:
 
 ```bash
 cd instance/TTFT_predictor
 python prefill_prediction_server.py
 ```
 
-默认行为：
+The current direct-run entry point starts uvicorn with:
 
-- 服务启动时先做一次轻量初始化
-- 然后在后台异步执行真实 warmup
-- 预测接口在 warmup 未完成前也可以先返回一个可用结果
+```text
+host = 172.18.0.250
+port = 9003
+```
 
-默认服务地址写在代码里：
-
-- host: `172.18.0.250`
-- port: `9000`
-
-如果要改部署地址，直接修改 `[prefill_prediction_server.py]` 末尾的 `uvicorn.run(...)` 即可。
-
-## Warmup 使用说明
-
-### 轻量 warmup
-
-`prefill_predictor.py` 在首次初始化时会先注入少量 dummy data，优点是启动快，缺点是精度一般。
-
-适合场景：
-
-- 服务刚启动
-- 只想尽快得到一个大致可用的 TTFT 估计
-
-### 详细 warmup
-
-更推荐的方式是执行 `perform_detailed_warmup(...)`，它会：
-
-1. 遍历一组 `(batch_size, prompt_length)` 配置
-2. 通过 `request_generator.py` 发送真实请求
-3. 等待外部将真实 prefill 时间回流到回归器
-4. 用采集到的数据重新拟合模型
-
-默认测试范围定义在 `[prefill_predictor.py]`：
-
-- `BATCH_SIZES_TO_TEST = range(1, 9)`
-- `TOKEN_LENGTHS_TO_TEST = range(64, 2048, 64)`
-- 并过滤 `bs * pl <= 10000`
-
-你可以直接修改：
-
-- `VLLM_CONFIG_DEFAULT`
-- `WARM_UP_CONFIGS_DEFAULT`
-
-来适配你的模型、服务地址和测试范围。
-
-## 配置项说明
-
-### `VLLM_CONFIG_DEFAULT`
-
-位于 `[prefill_predictor.py]`。
-
-主要字段：
-
-- `host`：目标 vLLM 服务地址
-- `port`：目标 vLLM 服务端口
-- `model_id`：请求时使用的模型标识
-- `tokenizer_path`：本地 tokenizer 路径
-
-### `WARM_UP_CONFIGS_DEFAULT`
-
-表示 warmup 时要测试的 `(batch_size, prompt_length)` 组合。
-
-如果你模型更大或者机器更弱，建议适当缩小范围，例如减少：
-
-- 最大 `batch_size`
-- 最大 `prompt_length`
-- `repeats`
-
-否则 warmup 时间会明显变长。
-
-## 与调度器集成建议
-
-如果要把它接到调度器里，推荐使用下面的模式：
-
-1. 调度前调用 `/predict` 或 `predict_ttft(...)`
-2. 根据预测结果做请求分配或排队决策
-3. 请求完成后，把真实 prefill 时间通过 `/report_prefill` 回流
-4. 周期性或启动后执行一次 `perform_detailed_warmup(...)`
-
-这样预测器既能快速返回，又能随着真实流量持续修正。
-
-## 常见问题
-
-### 1. 为什么第一次预测不准
-
-因为模型刚启动时通常只用了 dummy data，还没有完成真实 warmup。
-
-建议：
-
-- 启动后先执行一次详细 warmup
-- 或者让系统运行一段时间，持续回流真实 prefill 数据
-
-### 2. 为什么预测值会是 0 或非常小
-
-常见原因：
-
-- 模型还没拟合成功
-- 输入数据非法
-- 上报的 `prefill_time_seconds` 被过滤掉了
-
-当前过滤逻辑会丢弃：
-
-- 小于 `0.001s`
-- 大于 `60s`
-
-### 3. 为什么 prompt 长度和真实 token 数不完全一致
-
-`request_generator.py` 是根据 tokenizer 近似生成目标 token 数的 prompt，实际生成文本可能会有轻微偏差。这对 warmup 一般是可接受的。
-
-## 快速开始
-
-### 直接启动服务
+For production-style deployment, prefer an explicit uvicorn command so host, port, workers, and reload behavior are controlled outside the source file:
 
 ```bash
-cd instance/TTFT_predictor
-python prefill_prediction_server.py
+uvicorn prefill_prediction_server:app --host 0.0.0.0 --port 9003
 ```
-### 完成曲线拟合
-移步至`proxy/metrics/`
+
+### 6.1 Health check
+
+```bash
+curl http://127.0.0.1:9003/
+```
+
+Response shape:
+
+```json
+{
+  "status": "ok",
+  "message": "TTFT Predictor is running."
+}
+```
+
+### 6.2 Predict endpoint
+
+```bash
+curl -X POST http://127.0.0.1:9003/predict \
+  -H "Content-Type: application/json" \
+  -d '{"batch_size": 4, "prompt_length": 1024}'
+```
+
+Response shape:
+
+```json
+{
+  "predicted_ttft_seconds": 0.185,
+  "predicted_ttft_ms": 185.0
+}
+```
+
+### 6.3 Feedback endpoint
+
+```bash
+curl -X POST http://127.0.0.1:9003/report_prefill \
+  -H "Content-Type: application/json" \
+  -d '{"batch_size": 4, "prompt_length": 1024, "prefill_time_seconds": 0.185}'
+```
+
+Response shape:
+
+```json
+{
+  "status": "received",
+  "msg": "Data queued for model update"
+}
+```
+
+If `batch_size` is omitted from `/report_prefill`, the service currently defaults it to `1` before adding the sample.
+
+---
+
+## 7. Runtime flow
+
+When `prefill_prediction_server.py` starts:
+
+1. The FastAPI lifespan hook calls `predict_ttft(batch_size=1, prompt_length=1)`.
+2. This initializes the singleton `PrefillTimeRegressor` and seeds it with a few dummy samples for fast cold start.
+3. A background task waits briefly so the HTTP service can become available.
+4. The background task runs `perform_detailed_warmup(repeats=3)`.
+5. `/predict` remains available while warmup is running.
+6. `/report_prefill` can asynchronously add real feedback samples.
+
+This design avoids blocking service startup on a full benchmark while still allowing the model to become more accurate after warmup and real traffic feedback.
+
+---
+
+## 8. Warmup details
+
+### 8.1 Lightweight cold start
+
+The first call to `get_regressor()` creates the regressor and seeds it with a small dummy dataset. This gives the scheduler a usable estimate immediately, but the values should not be treated as calibrated.
+
+Use this state only for:
+
+- service startup,
+- smoke tests,
+- early scheduling before measured data is available.
+
+### 8.2 Detailed warmup
+
+`perform_detailed_warmup(...)` is the recommended calibration path. It:
+
+1. clears old samples,
+2. iterates through `WARM_UP_CONFIGS_DEFAULT`,
+3. sends real requests through `request_generator.py`,
+4. collects repeated TTFT samples,
+5. rewrites the collected samples to the current `(batch_size, prompt_length)` configuration,
+6. fits the regression model after all configurations complete,
+7. prints fitted coefficients.
+
+The default `repeats=3` is a balance between startup cost and robustness. Increase repeats for smoother coefficients; reduce repeats when you only need a quick approximate model.
+
+---
+
+## 9. Batch sample policy
+
+`prefill_regressor.py` can summarize a batch of concurrent TTFT measurements with different policies through `batch_sample_policy`:
+
+| Policy | Training sample value |
+| --- | --- |
+| `mid_minmax` | `(min_ttft + max_ttft) / 2`; current default. |
+| `mean_ttft` or unknown value | Average of valid per-request TTFT values. |
+| `max_arrival` | Maximum first-token arrival offset within the round. |
+| `max_ttft` | Maximum valid per-request TTFT. |
+| `min_ttft` | Minimum valid per-request TTFT. |
+
+`mid_minmax` is useful when a batch contains mild pseudo-serialization and the midpoint between fastest and slowest requests is a more stable training target than either extreme.
+
+---
+
+## 10. Scheduler integration pattern
+
+A typical CacheRoute integration loop is:
+
+1. Before dispatch, estimate the prefill stage with `/predict` or `predict_ttft(...)`.
+2. Use the estimate in queueing, batching, or routing decisions.
+3. After the request reaches first token, compute the measured prefill/TTFT value.
+4. Report the measurement through `/report_prefill` or `update_prefill_data(...)`.
+5. Periodically rerun detailed warmup after major deployment changes.
+
+This keeps the predictor fast enough for online scheduling while still correcting drift from real traffic.
+
+---
+
+## 11. Troubleshooting
+
+### First predictions are inaccurate
+
+The model is probably still using dummy cold-start data or an incomplete warmup. Run detailed warmup and keep feeding measured values from real requests.
+
+### Prediction is zero or extremely small
+
+Common causes:
+
+- no fitted model yet,
+- invalid input values,
+- too little training data,
+- reported samples filtered out because they are below `0.001s` or above `60s`.
+
+### Warmup takes too long
+
+Reduce one or more of:
+
+- maximum `batch_size`,
+- maximum `prompt_length`,
+- `repeats`,
+- or the number of tested configurations.
+
+The default grid is broad and may be expensive on smaller GPUs.
+
+### Prompt length does not exactly match the target
+
+`request_generator.py` uses the tokenizer to approximate prompts with a target token count. Small deviations are expected and usually acceptable for warmup.
+
+### Batch behavior looks unstable
+
+Check request dispatch gaps and the selected `batch_sample_policy`. Large dispatch gaps can prevent requests from landing in the same effective batch and may distort fitted coefficients.
+
+---
+
+## 12. Quick start checklist
+
+1. Edit `VLLM_CONFIG_DEFAULT` for your vLLM host, port, model id, and tokenizer path.
+2. Start the service:
+
+   ```bash
+   cd instance/TTFT_predictor
+   python prefill_prediction_server.py
+   ```
+
+3. Check health:
+
+   ```bash
+   curl http://127.0.0.1:9003/
+   ```
+
+4. Run a prediction:
+
+   ```bash
+   curl -X POST http://127.0.0.1:9003/predict \
+     -H "Content-Type: application/json" \
+     -d '{"batch_size": 1, "prompt_length": 1024}'
+   ```
+
+5. Feed back real measurements through `/report_prefill` after requests complete.
+6. Re-run warmup after changing model, vLLM configuration, hardware, tensor parallelism, or scheduling policy.
+
+---
+
+## 13. Relationship to TPOT prediction
+
+TTFT prediction models the cost before the first generated token, which is dominated by prefill and request setup. TPOT prediction models the per-token decode stage after the first token. Scheduler-side latency estimates usually need both:
+
+```text
+total_generation_latency ~= predicted_TTFT + predicted_decode_time
+```
+
+Use this directory for prefill/first-token prediction and `instance/TPOT_predictor` for decode-token prediction.


### PR DESCRIPTION
## Summary
- Rewrite `instance/TPOT_predictor/README.md` in English with richer guidance for measurement scope, sequence-length semantics, collection modes, robust statistics, fitting, prediction, exports, and prefill-load comparison.
- Rewrite `instance/TTFT_predictor/README.md` in English with clearer model explanation, service API usage, warmup flow, batch sample policies, scheduler integration, and troubleshooting.
- Correct the TTFT service port documentation to match the current direct-run entry point: `9003`.

## Validation
- Checked the branch diff against `main`; only the two predictor README files changed.
- Verified the updates are documentation-only and do not modify runtime code.