### PR TITLE
Update README docs for frontend URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   <a href="#why-cacheroute">Why CacheRoute?</a> •
   <a href="#key-features">Features</a> •
   <a href="#architecture">Architecture</a> •
+  <a href="#frontend-urls">Frontend URLs</a> •
   <a href="#quick-start">Quick Start</a> •
   <a href="#api-usage">API</a> •
   <a href="#documentation">Docs</a>
@@ -64,7 +65,7 @@ CacheRoute addresses this problem by using KDN servers to store KVCache blocks f
 | ⚙️ **Compute-network-aware knowledge injection** | CacheRoute dynamically chooses between text recomputation and KVCache reuse. It predicts task cost at the proxy and selects the injection strategy based on current task queues, compute load, and network load. |
 | 🧭 **Knowledge-oriented cross-system routing** | CacheRoute parses the knowledge requirement before resource-pool scheduling. The scheduler jointly considers knowledge availability, system load, and topology information, and routes requests to the LLM system that can serve the required knowledge more efficiently. |
 | 🗂️ **KDN-based KV cache management** | CacheRoute follows Knowledge Delivery Networks' idea, using dedicated KDN servers to register, store, query, and inject KV cache blocks for reusable knowledge. This enables external knowledge to be reused across LLM systems instead of being repeatedly recomputed. |
-| 📊 **Optional Instance resource dashboard** | CacheRoute provides a Rust resource agent and a lightweight dashboard to visualize local Instance CPU, memory, GPU, network, and admission-state snapshots for validation. This dashboard does not drive Scheduler decisions yet. |
+| 📊 **Proxy browser UI and Instance resource dashboard** | CacheRoute provides a browser-based Proxy observability dashboard and an optional Instance resource dashboard. They visualize control-plane status, Instance liveness, resource snapshots, topology information, and short-term resource trends without changing scheduling behavior. |
 
 ---
 
@@ -77,22 +78,36 @@ CacheRoute separates global routing, local injection decision, and KV cache mana
 </p>
 
 - **Scheduler:** performs global resource-pool selection and knowledge-oriented task routing.
-- **Proxy:** manages local task queues and selects the knowledge injection strategy.
+- **Proxy:** manages local task queues, selects knowledge injection strategy, and exposes the main Proxy browser UI.
 - **Instance:** connects CacheRoute with vLLM + LMCache and handles execution signaling.
 - **KDN Server:** stores reusable knowledge and injects KVCache blocks when needed.
 - **Resource Agent/Dashboard:** optionally observes local Instance resource snapshots for validation and future control-plane integration.
 
 ### Default ports
 
-| Component | Service Plane | Control Plane |
+| Component | Service Plane | Control Plane / Auxiliary |
 |---|---:|---:|
 | Scheduler | 7001 | 7002 |
 | Proxy | 8001 | 8002 |
-| Instance | 9001 | - |
+| Proxy UI | - | 8202 |
+| Client UI | - | 7071 |
+| Instance | 9001 | 9002 |
 | vLLM | 8000 | - |
 | KDN Server | 9101 | - |
 | Resource Agent (optional) | 9201 | - |
-| Resource Dashboard (optional) | 9202 | - |
+| Instance Resource Dashboard (optional) | - | 9202 |
+
+### Frontend URLs
+
+| Component | Frontend | Default URL | How to start | Status |
+|---|---|---|---|---|
+| Proxy | Proxy browser observability dashboard | `http://127.0.0.1:8202` | `cd test && python3 demo_proxy.py ...` starts it by default and prints the URL. Use `--no-proxy-ui` to disable it. | Available |
+| Instance | Browser resource dashboard | `http://127.0.0.1:9202` | `python3 instance/resource_dashboard/dashboard_server.py --dashboard-listen 0.0.0.0:9202 --agent-listen 127.0.0.1:9201` | Available |
+| Client | Browser request UI | `http://127.0.0.1:7071/ui/client` | `cd test && python3 demo_client.py --with-ui` | Available |
+| Scheduler | Scheduler browser UI | TBD | TBD | Planned |
+| KDN Server | KDN browser UI | TBD | TBD | Planned |
+
+The frontend URLs above assume a single-machine demo with loopback addresses. In containers without host networking, expose the corresponding UI ports or replace `127.0.0.1` with the host / forwarded address.
 
 ### System Workflow
 
@@ -101,7 +116,7 @@ CacheRoute separates global routing, local injection decision, and KV cache mana
 3. The Proxy predicts the cost of text-based and KVCache-based injection.
 4. The KDN Server injects reusable KVCache blocks when KVCache reuse is selected.
 5. The Instance forwards the request to vLLM + LMCache and returns the response.
-6. Optionally, the Resource Agent and Dashboard visualize local Instance resource snapshots for debugging and validation.
+6. Optionally, the Proxy UI and Instance Resource Dashboard visualize control-plane and resource state for debugging and validation.
 
 ---
 
@@ -148,7 +163,9 @@ python3 demo_instance.py --port 9001 --host 127.0.0.1
 python3 demo_client.py --with-ui
 ```
 
-Then, you can use the client_cli to send requests (see example in `API Usage`) to the scheduler and see the entire CacheRoute workflow.
+`demo_proxy.py` starts the Proxy browser UI by default and prints a URL similar to `http://127.0.0.1:8202`. `demo_client.py --with-ui` starts the Client browser UI at `http://127.0.0.1:7071/ui/client` by default.
+
+Then, you can use the client_cli or Client UI to send requests (see example in `API Usage`) to the scheduler and see the entire CacheRoute workflow.
 
 ### Option 2: Full CacheRoute Deployment
 
@@ -384,6 +401,7 @@ CacheRoute is under active development. The current release supports:
 - Proxy selection based on topology, load safety window, and knowledge history.
 - Proxy-side dynamic injection strategy selection.
 - KDN-based text registration and KVCache registration.
+- Proxy browser UI for control-plane, topology, Instance liveness, and resource-snapshot observability.
 - Optional Instance resource snapshots through a Rust agent and dashboard.
 - Debugging APIs such as `/debug/status` and `/debug/strategy`.
 
@@ -402,7 +420,10 @@ curl -s http://127.0.0.1:7001/debug/strategy
 - [x] Proxy-side dynamic injection strategy selection
 - [x] KDN-based text and KVCache registration
 - [x] OpenAI-compatible request forwarding
+- [x] Proxy browser observability UI
 - [x] Optional Instance resource dashboard
+- [ ] Scheduler browser UI
+- [ ] KDN Server browser UI
 - [ ] More deployment examples
 - [ ] Benchmark scripts and reproducible evaluation
 - [ ] More KV cache placement policies

--- a/UI/proxy_ui/README.md
+++ b/UI/proxy_ui/README.md
@@ -1,30 +1,30 @@
 # CacheRoute Proxy UI
 
-Lightweight browser dashboard for observing the Proxy control plane without changing scheduling, forwarding, KDN, or KVCache behavior.
+`UI/proxy_ui/` contains the browser dashboard for observing the CacheRoute Proxy control plane. It is frontend / observability only: it does not change scheduling, forwarding, KDN, KVCache, Instance selection, or Resource Agent reporting behavior.
 
-## Default behavior in `demo_proxy.py`
+## Default URL
 
-`test/demo_proxy.py` starts the browser Proxy UI by default for demo usability. The UI is observability-only: if it fails to start, `demo_proxy.py` prints a warning and continues starting the Proxy data/control planes.
+When launched by `test/demo_proxy.py`, the default browser URL is:
 
-Useful flags:
+```text
+http://127.0.0.1:8202
+```
 
-- `--no-proxy-ui`: disable the UI subprocess.
-- `--proxy-ui-listen HOST:PORT`: choose where the UI server listens, default `127.0.0.1:8202`.
-- `--proxy-ui-url URL`: choose the browser-facing URL printed in logs, useful when tunneling or forwarding ports.
+`demo_proxy.py` starts the Proxy UI by default for demo usability. If the UI fails to start, the demo prints a warning and continues starting the Proxy data plane and control plane.
 
-When the UI starts correctly, the demo prints:
+Typical startup log:
 
 ```text
 [demo_proxy] Proxy UI available at: http://127.0.0.1:8202
 ```
 
-If the UI subprocess exits early, cannot import, or the port is occupied, the demo prints a warning like:
+Failure example:
 
 ```text
 [demo_proxy][WARN] Proxy UI failed to start: ...
 ```
 
-## Run with demo proxy
+## Run with demo Proxy
 
 ```bash
 cd test
@@ -35,14 +35,18 @@ python3 demo_proxy.py \
   --injection-strategy iws
 ```
 
-Disable the UI when needed:
+Useful flags:
 
-```bash
-cd test
-python3 demo_proxy.py --no-proxy-ui
-```
+| Flag | Description |
+|---|---|
+| `--proxy-ui` | Explicitly enable the browser Proxy UI. This is already the demo default. |
+| `--no-proxy-ui` | Disable the UI subprocess. |
+| `--proxy-ui-listen HOST:PORT` | UI server listen address, default `127.0.0.1:8202`. |
+| `--proxy-ui-url URL` | Browser-facing URL printed in logs, useful for SSH tunnels or forwarded container ports. |
 
 ## Run standalone
+
+Use this when Proxy is already running and you only want to start the UI server manually:
 
 ```bash
 PROXY_UI_PROXY_CP_URL=http://127.0.0.1:8002 \
@@ -50,31 +54,84 @@ PROXY_UI_SCHEDULER_CP_URL=http://127.0.0.1:7002 \
 python3 -m uvicorn UI.proxy_ui.proxy_ui_server:app --host 127.0.0.1 --port 8202
 ```
 
-## What the first version shows
+Open:
 
-- Proxy health and debug status.
-- Instance pool records from `/v1/instance/list?include_dead=true`, including accurate `is_alive` state when the Proxy API provides it.
-- Instance resource snapshots from `/debug/instance_resources`.
-- KDN topology links from `/v1/topology/kdn_links`.
-- Best-effort Scheduler registration state when `PROXY_UI_PROXY_ID` is configured.
+```text
+http://127.0.0.1:8202
+```
 
-The UI polls the Proxy control plane through the UI server, so the browser does not need direct CORS access to Proxy APIs. Optional Scheduler/topology failures are shown as unavailable states and do not block the local Proxy and Instance panels from rendering.
+## What the dashboard shows
 
-## Polished dashboard features
+The polished Proxy UI exposes both current state and short in-browser trends.
 
-upgrades the first Proxy UI into a richer frontend-only dashboard while keeping the same observability-only contract.
+### Summary and health
 
-- Sticky top navigation with Proxy/Scheduler badges, last refresh time, refresh, pause/resume, and theme controls.
-- Auto-refresh interval selector for 1s / 3s / 5s / 10s polling.
-- Local filters for alive-only, stale-only, resources-only, and instance-id/host search.
-- Short in-browser chart history for CPU, memory, GPU utilization, network RX/TX, and alive/stale counts.
-- Per-instance cards with liveness badges, resource freshness badges, progress bars, network mini-metrics, and admission state.
-- Sortable Instance table by state, age, CPU, memory, GPU, or resource report time.
-- Topology, Scheduler, and Raw JSON tabs so raw payloads remain available without dominating the main dashboard.
-- Copy buttons for diagnostics JSON and individual raw payloads.
-- Optional Scheduler/topology failures render as unavailable/degraded states and do not block local Proxy/Instance panels.
+- Proxy health and `/debug/status` summary.
+- Scheduler registration status, best effort and optional.
+- Alive / stale / total Instance counts.
+- Visible resource-report count.
+- KDN topology-link count.
+- Last refresh time and polling state.
 
-All controls are browser-local display controls only. They do not mutate Scheduler routing, Proxy instance selection, Proxy injection strategy, KDN behavior, KVCache behavior, Instance forwarding, or Resource Agent reporting semantics.
+### Controls
+
+- `Refresh now`.
+- `Pause polling` / `Resume polling`.
+- Auto-refresh interval selector: 1s / 3s / 5s / 10s.
+- Alive-only, stale-only, resources-only filters.
+- Instance ID / host search.
+- Sort selector for state, age, CPU, memory, GPU, and resource report time.
+- Clear chart history.
+- Copy diagnostics JSON.
+- Theme toggle.
+
+All controls are local browser display controls only.
+
+### Charts
+
+The UI keeps a short in-browser history buffer and draws lightweight Canvas charts for:
+
+- CPU average utilization.
+- Memory used ratio.
+- GPU average utilization.
+- Network RX / TX Mbps.
+- Alive / stale Instance counts.
+
+No backend persistence is required. Missing metrics degrade to empty chart segments.
+
+### Instance and resource views
+
+- Per-Instance cards with liveness badges, address, last-seen age, resource freshness, admission state, CPU/memory/GPU progress bars, and network mini-metrics.
+- Detailed Instance table with sorting and local filtering.
+- Resource snapshot table with freshness and admission-state fields.
+- Topology, Scheduler, and Raw JSON tabs.
+- Copy buttons for raw diagnostic payloads.
+
+## API sources
+
+The UI server proxies browser requests to existing Proxy / Scheduler APIs:
+
+| UI endpoint | Source |
+|---|---|
+| `GET /api/config` | UI runtime configuration. |
+| `GET /api/proxy/healthz` | Proxy control plane `/healthz`. |
+| `GET /api/proxy/status` | Proxy control plane `/debug/status`. |
+| `GET /api/proxy/instances?include_dead=true` | Proxy control plane `/v1/instance/list`. |
+| `GET /api/proxy/resources?include_dead=true` | Proxy control plane `/debug/instance_resources`. |
+| `GET /api/proxy/topology` | Proxy control plane `/v1/topology/kdn_links`. |
+| `GET /api/scheduler/proxy` | Scheduler control plane `/v1/proxy/list`, best effort. |
+
+Optional Scheduler/topology failures are displayed as unavailable or degraded states. They do not block the local Proxy and Instance panels from rendering.
+
+## Related frontend URLs
+
+| Component | Default frontend URL | Notes |
+|---|---|---|
+| Proxy UI | `http://127.0.0.1:8202` | This dashboard. Started by `demo_proxy.py` by default. |
+| Instance Resource Dashboard | `http://127.0.0.1:9202` | Browser fallback for `instance/resource_dashboard/dashboard_server.py`. |
+| Client UI | `http://127.0.0.1:7071/ui/client` | Started by `demo_client.py --with-ui`. |
+| Scheduler UI | TBD | Planned. |
+| KDN Server UI | TBD | Planned. |
 
 ## Validation steps
 
@@ -98,12 +155,6 @@ python3 demo_proxy.py \
   --injection-strategy iws
 ```
 
-Expected log when UI starts correctly:
-
-```text
-[demo_proxy] Proxy UI available at: http://127.0.0.1:8202
-```
-
 Start Instance:
 
 ```bash
@@ -123,12 +174,14 @@ curl -sS "http://127.0.0.1:8002/v1/instance/list?include_dead=true" | python3 -m
 curl -sS "http://127.0.0.1:8002/debug/instance_resources" | python3 -m json.tool
 ```
 
-Open the UI URL and confirm:
+Open the UI and confirm:
 
-- Proxy status is visible.
-- Instance pool rows are visible.
-- Resource snapshot rows update periodically.
-- Alive/stale state is accurate.
-- Scheduler unavailable state does not break the page.
-- Stopping `demo_proxy.py` cleans up the UI subprocess.
-- No scheduling, routing, injection, KDN, KVCache, or Instance forwarding behavior changed.
+- summary cards update periodically;
+- pause / resume works;
+- refresh interval changes take effect;
+- filters and search work;
+- Instance cards and table show alive / stale state correctly;
+- charts update as snapshots arrive;
+- Scheduler unavailable state does not break the page;
+- raw JSON can be expanded, collapsed, and copied;
+- stopping `demo_proxy.py` cleans up the UI subprocess.

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -21,8 +21,9 @@ Client
 |---|---:|---|
 | Service plane | `8001` | Receives Scheduler-forwarded OpenAI-compatible requests. |
 | Control plane | `8002` | Receives Instance registration, heartbeat, topology reports, resource snapshots, and debug queries. |
+| Browser UI | `8202` | Displays Proxy health, Instance liveness, resources, topology, Scheduler registration, charts, filters, and raw diagnostics. |
 
-The Proxy can run without a Scheduler during local demos. In that case, Scheduler registration may fail non-fatally, but Instance registration and resource reporting can still be validated through the Proxy control plane.
+The Proxy can run without a Scheduler during local demos. In that case, Scheduler registration may fail non-fatally, but Instance registration and resource reporting can still be validated through the Proxy control plane and Proxy UI.
 
 ## Directory structure
 
@@ -49,6 +50,8 @@ proxy/
 └── README.md
 ```
 
+The browser UI implementation lives outside this directory under [`UI/proxy_ui/`](../UI/proxy_ui/).
+
 ## Quick start
 
 Start Proxy from the `test` directory:
@@ -62,6 +65,18 @@ python3 demo_proxy.py \
   --injection-strategy iws
 ```
 
+`demo_proxy.py` starts the Proxy browser UI by default and prints:
+
+```text
+[demo_proxy] Proxy UI available at: http://127.0.0.1:8202
+```
+
+Open:
+
+```text
+http://127.0.0.1:8202
+```
+
 Common options:
 
 | Option | Description |
@@ -72,6 +87,36 @@ Common options:
 | `--injection-strategy` | Knowledge injection strategy. Use `default` or `iws`. |
 | `--ready-release-policy` | Ready queue release policy: `ordered` or `text_bypass`. |
 | `--kdn-links-json` | Optional static KDN topology metadata. |
+| `--proxy-ui` | Explicitly enable the browser Proxy UI. This is already the default. |
+| `--no-proxy-ui` | Disable the browser Proxy UI subprocess. |
+| `--proxy-ui-listen HOST:PORT` | UI server listen address, default `127.0.0.1:8202`. |
+| `--proxy-ui-url URL` | Browser-facing URL printed in logs, useful for tunnels / forwarded ports. |
+
+## Proxy browser UI
+
+The Proxy UI is the main browser observability dashboard for the Proxy runtime. It is frontend-only and does not mutate Scheduler routing, Proxy Instance selection, injection strategy, KDN behavior, KVCache behavior, or Instance forwarding.
+
+Default URL:
+
+```text
+http://127.0.0.1:8202
+```
+
+It shows:
+
+- Proxy health and `/debug/status`.
+- Scheduler registration state, best effort.
+- Instance pool and TTL-derived alive / stale state.
+- Instance resource snapshots reported by demo Instances.
+- Per-Instance resource cards and sortable tables.
+- CPU, memory, GPU, network, and alive/stale trend charts.
+- KDN topology links.
+- Raw diagnostic JSON with copy actions.
+- Local controls for refresh, pause/resume, polling interval, filters, search, sort, chart history, and theme.
+
+The UI server proxies requests through `UI/proxy_ui/proxy_ui_server.py` so the browser does not need direct CORS access to Proxy or Scheduler APIs.
+
+See [`UI/proxy_ui/README.md`](../UI/proxy_ui/README.md) for details.
 
 ## Startup lifecycle
 
@@ -79,13 +124,14 @@ Common options:
 Proxy startup
   ├── initialize InstancePool
   ├── start Proxy control plane on :8002
+  ├── start Proxy browser UI on :8202 in demo mode, unless disabled
   ├── load Instance selection strategy
   ├── register to Scheduler control plane, non-fatal for local demos
   ├── report topology metadata to Scheduler, if configured
   └── start heartbeat loop
 ```
 
-During shutdown, the Proxy tries to unregister from the Scheduler. If the process is killed directly, Scheduler removes it after heartbeat expiry.
+During shutdown, the Proxy tries to unregister from the Scheduler. If the process is killed directly, Scheduler removes it after heartbeat expiry. In demo mode, the UI subprocess started by `demo_proxy.py` is cleaned up on exit.
 
 ## Control-plane APIs
 
@@ -93,6 +139,7 @@ During shutdown, the Proxy tries to unregister from the Scheduler. If the proces
 
 ```text
 GET /healthz
+GET /debug/status
 ```
 
 ### Instance management
@@ -310,6 +357,8 @@ Useful commands:
 | `:scheduler` | Query Scheduler control plane. |
 | `:exit` / `:quit` | Exit. |
 
+The browser Proxy UI covers the same observability surface and adds charts, cards, filters, and raw diagnostic copy actions.
+
 ## Validation
 
 ### 1. Start Proxy
@@ -321,6 +370,12 @@ python3 demo_proxy.py \
   --port 8001 \
   --strategy round_robin \
   --injection-strategy iws
+```
+
+Open the Proxy UI printed by the demo:
+
+```text
+http://127.0.0.1:8202
 ```
 
 ### 2. Start Instance with default demo resource monitoring
@@ -337,6 +392,12 @@ python3 demo_instance.py \
 
 ```bash
 curl -sS "http://127.0.0.1:8002/debug/instance_resources" | python3 -m json.tool
+```
+
+Or use the browser UI:
+
+```text
+http://127.0.0.1:8202
 ```
 
 ### 4. Run the e2e smoke validation
@@ -366,9 +427,12 @@ Common environment variables:
 | `PROXY_INSTANCE_TTL_S` | Instance alive TTL. |
 | `PREPARE_CONCURRENCY` | Prepare queue concurrency. |
 | `READY_CONCURRENCY` | Ready worker concurrency. |
+| `PROXY_UI_LISTEN` | Optional default for the Proxy UI listen address. |
+| `PROXY_UI_URL` | Optional browser-facing URL printed by `demo_proxy.py`. |
 
 ## Notes
 
 - Resource snapshots are visible in Proxy state but do not yet drive routing.
 - Repeated successful resource reports are intentionally quiet to avoid log flooding.
 - `unknown_instance` warnings usually mean a stale or external Instance process is still heartbeating to the Proxy control plane.
+- The Proxy UI is the preferred visual entry point for Proxy observability during demos and experiments.

--- a/test/README.md
+++ b/test/README.md
@@ -8,19 +8,32 @@ The default single-machine demo ports are:
 |---|---:|---:|
 | Scheduler | `7001` | `7002` |
 | Proxy | `8001` | `8002` |
+| Proxy UI | - | `8202` |
+| Client UI | - | `7071` |
 | Instance | `9001` | `9002` |
 | KDN Server | `9101` | - |
 | Resource Agent | `9201` | - |
+| Instance Resource Dashboard | - | `9202` |
+
+## Browser frontend URLs
+
+| Component | Default URL | Started by | Notes |
+|---|---|---|---|
+| Proxy UI | `http://127.0.0.1:8202` | `demo_proxy.py` | Enabled by default. Use `--no-proxy-ui` to disable. |
+| Client UI | `http://127.0.0.1:7071/ui/client` | `demo_client.py --with-ui` | Sends OpenAI-compatible requests to Scheduler. |
+| Instance Resource Dashboard | `http://127.0.0.1:9202` | `instance/resource_dashboard/dashboard_server.py` | Browser fallback for the Rust Resource Agent. |
+| Scheduler UI | TBD | TBD | Planned. |
+| KDN Server UI | TBD | TBD | Planned. |
 
 ## Main demo files
 
 | File | Purpose | Typical usage |
 |---|---|---|
 | `demo_scheduler.py` | Starts Scheduler service plane and control plane. Use it when validating full Client -> Scheduler -> Proxy routing. | `python3 demo_scheduler.py --cacheroute` |
-| `demo_proxy.py` | Starts Proxy service plane and Proxy control plane. It registers to Scheduler if available, and accepts Instance registration/resource reports on `8002`. | `python3 demo_proxy.py --strategy round_robin --injection-strategy iws` |
+| `demo_proxy.py` | Starts Proxy service plane, Proxy control plane, and the browser Proxy UI by default. It registers to Scheduler if available, and accepts Instance registration/resource reports on `8002`. | `python3 demo_proxy.py --strategy round_robin --injection-strategy iws` |
 | `demo_instance.py` | Starts an Instance service. By default it registers to Proxy, starts or reuses the Rust Resource Agent, reports resource snapshots after registration, and cleans up demo-owned agent processes on shutdown. | `python3 demo_instance.py --host 127.0.0.1 --port 9001 --proxy-cp-url http://127.0.0.1:8002` |
 | `demo_kdn.py` | Starts the KDN Server for text/KVCache metadata query and registration. | `python3 demo_kdn.py` |
-| `demo_client.py` | Sends demo requests through CacheRoute. Can be used with or without UI depending on flags. | `python3 demo_client.py --with-ui` |
+| `demo_client.py` | Sends demo requests through CacheRoute. Can be used with or without browser UI. | `python3 demo_client.py --with-ui` |
 | `demo_run.py` | Historical helper for running a demo flow. Check the script body before relying on it for new experiments. | `python3 demo_run.py` |
 | `demo_embedding.py` | Local embedding / retrieval validation helper. | `python3 demo_embedding.py` |
 | `demo_request_handle.py` | Request parsing and request-handle validation helper. | `python3 demo_request_handle.py` |
@@ -52,6 +65,12 @@ python3 demo_proxy.py \
   --injection-strategy iws
 ```
 
+`demo_proxy.py` prints the Proxy UI URL when the UI starts successfully:
+
+```text
+[demo_proxy] Proxy UI available at: http://127.0.0.1:8202
+```
+
 Terminal 2:
 
 ```bash
@@ -70,11 +89,17 @@ python3 demo_instance.py \
 4. periodically report snapshots to `http://127.0.0.1:8002/v1/instance/resource_snapshot`;
 5. kill only the Resource Agent process group it started when Instance exits.
 
-Inspect resource status:
+Inspect resource status with curl:
 
 ```bash
 curl -sS "http://127.0.0.1:8002/debug/instance_resources" | python3 -m json.tool
 curl -sS "http://127.0.0.1:8002/v1/instance/list?include_dead=true" | python3 -m json.tool
+```
+
+Or open the Proxy UI:
+
+```text
+http://127.0.0.1:8202
 ```
 
 Disable resource monitoring:
@@ -89,6 +114,30 @@ Use a non-default Resource Agent port:
 python3 demo_instance.py \
   --resource-agent-listen 127.0.0.1:19201 \
   --resource-agent-url http://127.0.0.1:19201
+```
+
+## Client browser UI
+
+Start the Client UI:
+
+```bash
+cd test
+python3 demo_client.py --with-ui
+```
+
+Open:
+
+```text
+http://127.0.0.1:7071/ui/client
+```
+
+Override the listen address or Scheduler URL when needed:
+
+```bash
+python3 demo_client.py --with-ui \
+  --ui-host 0.0.0.0 \
+  --ui-port 7071 \
+  --scheduler-url http://127.0.0.1:7001/v1/chat/completions
 ```
 
 ## Resource-monitor e2e smoke script
@@ -121,6 +170,7 @@ python3 demo_scheduler.py --cacheroute
 # Terminal 3: Proxy
 cd test
 python3 demo_proxy.py --strategy round_robin --injection-strategy iws
+# Open http://127.0.0.1:8202 for the Proxy UI.
 
 # Terminal 4: Instance
 cd test
@@ -129,6 +179,7 @@ python3 demo_instance.py --host 127.0.0.1 --port 9001 --proxy-cp-url http://127.
 # Terminal 5: Client
 cd test
 python3 demo_client.py --with-ui
+# Open http://127.0.0.1:7071/ui/client for the Client UI.
 ```
 
 For focused Proxy/Instance development, Scheduler and KDN are optional unless the specific feature under test requires them.
@@ -138,13 +189,13 @@ For focused Proxy/Instance development, Scheduler and KDN are optional unless th
 Check ports:
 
 ```bash
-ss -ltnp | grep -E "7001|7002|8001|8002|9001|9002|9101|9201" || true
+ss -ltnp | grep -E "7001|7002|7071|8001|8002|8202|9001|9002|9101|9201|9202" || true
 ```
 
 Find stale demo processes:
 
 ```bash
-ps -ef | grep -E "demo_scheduler|demo_proxy|demo_instance|demo_kdn|resource_agent|cargo" | grep -v grep
+ps -ef | grep -E "demo_scheduler|demo_proxy|demo_instance|demo_kdn|demo_client|proxy_ui|resource_agent|cargo" | grep -v grep
 ```
 
 If old external processes are heartbeating to Proxy with unknown IDs, inspect their environment:


### PR DESCRIPTION
## Summary

- Add a root README `Frontend URLs` table summarizing browser entry points for Proxy, Instance, Client, Scheduler, and KDN Server.
- Mark Scheduler UI and KDN Server UI as TBD.
- Update Proxy UI README to reflect the polished dashboard, controls, charts, API sources, and validation flow.
- Update Proxy README and test README with the Proxy UI default URL, demo flags, and frontend validation notes.

## Notes

- Documentation-only PR.
- No runtime code changed.
- KDN Server and Scheduler frontends are intentionally listed as TBD, per current roadmap.