### PR TITLE
Report Proxy pool resource state to Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ The frontend URLs above assume a single-machine demo with loopback addresses. In
 3. The Proxy predicts the cost of text-based and KVCache-based injection.
 4. The KDN Server injects reusable KVCache blocks when KVCache reuse is selected.
 5. The Instance forwards the request to vLLM + LMCache and returns the response.
-6. Optionally, the Proxy UI and Instance Resource Dashboard visualize control-plane and resource state for debugging and validation.
+6. Instance resource snapshots can flow through the Proxy control plane, where the Proxy aggregates a compact `pool_resource` snapshot and reports it to the Scheduler through register/heartbeat payloads. The Scheduler stores this state for debug visibility without changing routing decisions.
+7. Optionally, the Proxy UI and Instance Resource Dashboard visualize control-plane and resource state for debugging and validation.
 
 ---
 

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -94,6 +94,16 @@ async def _build_proxy_topology_meta() -> Dict[str, Any]:
     return {"kdn_links": merged_links} if merged_links else {}
 
 
+def _build_pool_resource_snapshot(app: FastAPI) -> Dict[str, Any]:
+    pool: InstancePool = app.state.instance_pool  # type: ignore
+    return pool.build_pool_resource_snapshot(
+        proxy_id=PROXY_ID,
+        capacity=PROXY_MAX_CAPACITY,
+        prepare_queue_depth=None,
+        ready_queue_depth=None,
+    )
+
+
 def _squelch_noisy_loggers():
     # http client
     logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -122,6 +132,7 @@ async def lifespan(app: FastAPI):
     ttl_s = int(os.environ.get("PROXY_INSTANCE_TTL_S", config.INSTANCE_ALIVE_TTL_S))
     app.state.instance_pool = InstancePool(ttl_s=ttl_s)  # type: ignore
     p_control_plane.set_pool(app.state.instance_pool)  # type: ignore
+    p_control_plane.set_pool_resource_context(PROXY_ID, PROXY_MAX_CAPACITY)
 
     # --- Load the proxy scheduling strategy for the data plane ---
     strategy_name = os.environ.get("PROXY_INSTANCE_STRATEGY", "round_robin")
@@ -190,6 +201,7 @@ async def lifespan(app: FastAPI):
             instance_count=PROXY_INSTANCE_COUNT,
             kv_mem_per_instance_gb=PROXY_KV_MEM_PER_INSTANCE_GB,
             kv_cache_update_policy=PROXY_KV_CACHE_UPDATE_POLICY,
+            pool_resource=_build_pool_resource_snapshot(app),
         )
         # Override the local default heartbeat interval with the interval suggested by the scheduler
         interval = float(reg.heartbeat_interval_s) if reg.heartbeat_interval_s else PROXY_HEARTBEAT_S
@@ -209,6 +221,7 @@ async def lifespan(app: FastAPI):
                 await client.heartbeat(
                     proxy_id=PROXY_ID,
                     meta_patch=await _build_proxy_topology_meta(),
+                    pool_resource=_build_pool_resource_snapshot(app),
                 )
                 await reporter.record(ok=True)
             except Exception as e:

--- a/proxy/resource/instance_pool.py
+++ b/proxy/resource/instance_pool.py
@@ -144,6 +144,109 @@ class InstancePool:
             it.resource = _resource_from_snapshot(snapshot=snapshot, reported_at=now, metadata=metadata or {})
             return True
 
+
+    def build_pool_resource_snapshot(
+        self,
+        proxy_id: str,
+        capacity: int = 0,
+        prepare_queue_depth: Optional[int] = None,
+        ready_queue_depth: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Build a compact Proxy pool-level resource snapshot for Scheduler reporting."""
+        now = time.time()
+        with self._lock:
+            items = list(self._items.values())
+
+        alive_items: List[InstanceInfo] = []
+        stale = 0
+        for it in items:
+            if (now - float(it.last_seen_at)) <= self._ttl_s:
+                alive_items.append(it)
+            else:
+                stale += 1
+
+        reporting = [it for it in alive_items if _has_resource(it.resource)]
+        freshness = [max(0.0, now - float(it.resource.resource_reported_at or now)) for it in reporting]
+
+        admission_counts = {"accepting": 0, "degraded": 0, "rejecting": 0}
+        for it in reporting:
+            state = (it.resource.admission_state or "").strip().lower()
+            if state in admission_counts:
+                admission_counts[state] += 1
+
+        missing_resource = max(0, len(alive_items) - len(reporting))
+        inflight_total = sum(int(it.load.inflight or 0) for it in alive_items)
+        qps_1m_total = sum(float(it.load.qps_1m or 0.0) for it in alive_items)
+        effective_capacity = int(capacity or 0)
+        load_ratio = inflight_total / max(effective_capacity, 1)
+
+        cpu_values = [float(it.resource.cpu_util) for it in reporting if it.resource.cpu_util is not None]
+        gpu_values = [float(it.resource.gpu_util_avg) for it in reporting if it.resource.gpu_util_avg is not None]
+        mem_used = sum(float(it.resource.memory_used_mb or 0.0) for it in reporting)
+        mem_total = sum(float(it.resource.memory_total_mb or 0.0) for it in reporting)
+        gpu_mem_used = sum(float(it.resource.gpu_mem_used_mb or 0.0) for it in reporting)
+        gpu_mem_total = sum(float(it.resource.gpu_mem_total_mb or 0.0) for it in reporting)
+        mem_free_ratios = [float(it.resource.memory_free_ratio) for it in reporting if it.resource.memory_free_ratio is not None]
+        rx_total = sum(float(it.resource.network_rx_mbps or 0.0) for it in reporting if it.resource.network_rx_mbps is not None)
+        tx_total = sum(float(it.resource.network_tx_mbps or 0.0) for it in reporting if it.resource.network_tx_mbps is not None)
+        has_rx = any(it.resource.network_rx_mbps is not None for it in reporting)
+        has_tx = any(it.resource.network_tx_mbps is not None for it in reporting)
+
+        if len(alive_items) == 0:
+            pool_state = "rejecting"
+        elif reporting and admission_counts["rejecting"] == len(reporting) and missing_resource == 0:
+            pool_state = "rejecting"
+        elif admission_counts["degraded"] or admission_counts["rejecting"] or missing_resource:
+            pool_state = "degraded"
+        else:
+            pool_state = "accepting"
+
+        return {
+            "schema_version": 1,
+            "proxy_id": proxy_id,
+            "generated_at": now,
+            "ttl_s": self._ttl_s,
+            "resource_freshness_s": _min_avg_max(freshness),
+            "instances": {
+                "total": len(items),
+                "alive": len(alive_items),
+                "stale": stale,
+                "with_resource": len(reporting),
+                "missing_resource": missing_resource,
+                "accepting": admission_counts["accepting"],
+                "degraded": admission_counts["degraded"],
+                "rejecting": admission_counts["rejecting"],
+            },
+            "load": {
+                "inflight_total": inflight_total,
+                "qps_1m_total": qps_1m_total,
+                "load_ratio": load_ratio,
+                "capacity": effective_capacity,
+                "prepare_queue_depth": prepare_queue_depth,
+                "ready_queue_depth": ready_queue_depth,
+            },
+            "utilization": {
+                "cpu_avg": _avg(cpu_values),
+                "cpu_max": max(cpu_values) if cpu_values else None,
+                "memory_used_mb": mem_used if reporting else None,
+                "memory_total_mb": mem_total if reporting else None,
+                "memory_used_ratio": _ratio(mem_used, mem_total),
+                "memory_free_ratio_min": min(mem_free_ratios) if mem_free_ratios else None,
+                "gpu_util_avg": _avg(gpu_values),
+                "gpu_util_max": max(gpu_values) if gpu_values else None,
+                "gpu_mem_used_mb": gpu_mem_used if reporting else None,
+                "gpu_mem_total_mb": gpu_mem_total if reporting else None,
+                "gpu_mem_used_ratio": _ratio(gpu_mem_used, gpu_mem_total),
+                "network_rx_mbps_total": rx_total if has_rx else None,
+                "network_tx_mbps_total": tx_total if has_tx else None,
+            },
+            "pool_admission_state": pool_state,
+            "pool_admission_reason": (
+                f"{admission_counts['accepting']} accepting, {admission_counts['degraded']} degraded, "
+                f"{admission_counts['rejecting']} rejecting, {len(alive_items)} alive"
+            ),
+        }
+
     def remove(self, instance_id: str) -> bool:
         with self._lock:
             return self._items.pop(instance_id, None) is not None
@@ -161,6 +264,24 @@ class InstancePool:
             if (now - int(it.last_seen_at)) <= self._ttl_s:
                 alive.append(it)
         return alive
+
+
+def _has_resource(resource: InstanceResource) -> bool:
+    return bool(resource.raw_resource) and resource.resource_reported_at is not None
+
+
+def _avg(values: List[float]) -> Optional[float]:
+    return (sum(values) / len(values)) if values else None
+
+
+def _min_avg_max(values: List[float]) -> Dict[str, Optional[float]]:
+    if not values:
+        return {"min": None, "avg": None, "max": None}
+    return {"min": min(values), "avg": sum(values) / len(values), "max": max(values)}
+
+
+def _ratio(used: float, total: float) -> Optional[float]:
+    return (used / total) if total > 0 else None
 
 
 def _as_float(value: Any) -> Optional[float]:

--- a/proxy/resource/p_control_plane.py
+++ b/proxy/resource/p_control_plane.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from typing import Any, Dict, List, Optional
 
@@ -23,11 +24,19 @@ _instance_kdn_links: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _kdn_links_lock = asyncio.Lock()
 _resource_snapshot_seen: set[str] = set()
 _unknown_resource_warn_at: Dict[str, float] = {}
+_proxy_id: str = os.environ.get("PROXY_ID", "unknown")
+_proxy_capacity: int = int(os.environ.get("PROXY_MAX_CAPACITY", "0") or 0)
 
 
 def set_pool(pool: InstancePool) -> None:
     global _pool
     _pool = pool
+
+
+def set_pool_resource_context(proxy_id: str, capacity: int = 0) -> None:
+    global _proxy_id, _proxy_capacity
+    _proxy_id = proxy_id
+    _proxy_capacity = int(capacity or 0)
 
 
 def get_pool() -> InstancePool:
@@ -251,6 +260,12 @@ async def list_instances(include_dead: bool = False) -> List[Dict[str, Any]]:
     return out
 
 
+
+
+@_control_plane.get("/debug/pool_resource")
+async def debug_pool_resource() -> Dict[str, Any]:
+    pool = get_pool()
+    return {"ok": True, "pool_resource": pool.build_pool_resource_snapshot(proxy_id=_proxy_id, capacity=_proxy_capacity)}
 
 
 @_control_plane.get("/debug/instance_resources")

--- a/proxy/sclient/scheduler_client.py
+++ b/proxy/sclient/scheduler_client.py
@@ -43,6 +43,7 @@ class SchedulerControlClient:
         instance_count: int = 0,
         kv_mem_per_instance_gb: float = 0.0,
         kv_cache_update_policy: str = "lru",
+        pool_resource: Optional[Dict[str, Any]] = None,
     ) -> RegisterResult:
         payload = {
             "proxy_id": proxy_id,
@@ -57,6 +58,8 @@ class SchedulerControlClient:
             "kv_mem_per_instance_gb": kv_mem_per_instance_gb,
             "kv_cache_update_policy": kv_cache_update_policy,
         }
+        if pool_resource is not None:
+            payload["pool_resource"] = pool_resource
         r = await self._client.post(f"{self.base_url}/v1/proxy/register", json=payload)
         r.raise_for_status()
         j = r.json()
@@ -73,6 +76,7 @@ class SchedulerControlClient:
         qps_1m: Optional[float] = None,
         gpu_util: Optional[float] = None,
         meta_patch: Optional[Dict[str, Any]] = None,
+        pool_resource: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {"proxy_id": proxy_id}
         # Include values only when present to avoid triggering server-side full overwrite to 0
@@ -84,6 +88,8 @@ class SchedulerControlClient:
             payload["gpu_util"] = gpu_util
         if meta_patch:
             payload["meta_patch"] = meta_patch
+        if pool_resource is not None:
+            payload["pool_resource"] = pool_resource
 
         r = await self._client.post(f"{self.base_url}/v1/proxy/heartbeat", json=payload)
         r.raise_for_status()

--- a/scheduler/resource/control_plane.py
+++ b/scheduler/resource/control_plane.py
@@ -19,6 +19,7 @@ Note:
 from __future__ import annotations
 
 import os
+import time
 # import time
 import uuid
 import asyncio
@@ -69,6 +70,7 @@ class ProxyRegisterRequest(BaseModel):
     instance_count: int = Field(default=0, ge=0)
     kv_mem_per_instance_gb: float = Field(default=0.0, ge=0.0)
     kv_cache_update_policy: str = Field(default="lru")
+    pool_resource: Optional[Dict[str, Any]] = None
 
 class ProxyRegisterResponse(BaseModel):
     """
@@ -94,6 +96,7 @@ class ProxyHeartbeatRequest(BaseModel):
     qps_1m: Optional[float] = None
     gpu_util: Optional[float] = None
     meta_patch: Optional[Dict[str, Any]] = None
+    pool_resource: Optional[Dict[str, Any]] = None
 
 
 class ProxyUnregisterRequest(BaseModel):
@@ -126,6 +129,8 @@ class ProxyInfoResponse(BaseModel):
     registered_at: float
     last_seen_at: float
     is_alive: bool
+    pool_resource: Optional[Dict[str, Any]] = None
+    pool_resource_reported_at: Optional[float] = None
 
 
 class KDNRegisterRequest(BaseModel):
@@ -263,6 +268,8 @@ def _to_response(info: ProxyInfo) -> ProxyInfoResponse:
         registered_at=float(info.registered_at),
         last_seen_at=float(info.last_seen_at),
         is_alive=info.is_alive(pool.ttl_s),
+        pool_resource=dict(info.pool_resource) if info.pool_resource is not None else None,
+        pool_resource_reported_at=info.pool_resource_reported_at,
     )
 
 
@@ -299,6 +306,8 @@ async def proxy_register(req: ProxyRegisterRequest):
                        kv_mem_per_instance_gb=float(req.kv_mem_per_instance_gb or 0.0),
                        kv_cache_pool_gb=float(inst_cnt) * float(kv_gb),
                        ),  # Registration starts with an empty load; heartbeats update it later
+        pool_resource=dict(req.pool_resource) if req.pool_resource is not None else None,
+        pool_resource_reported_at=time.time() if req.pool_resource is not None else None,
     )
     # Registration is essentially an upsert
     pool = get_pool()
@@ -334,7 +343,7 @@ async def proxy_heartbeat(req: ProxyHeartbeatRequest):
         )
 
     pool = get_pool()
-    ok = await pool.heartbeat(req.proxy_id, load=load, meta_patch=req.meta_patch)
+    ok = await pool.heartbeat(req.proxy_id, load=load, meta_patch=req.meta_patch, pool_resource=req.pool_resource)
     if not ok:
         # Failure: output immediately and count it as an error
         await _hb_agg.record_proxy(req.proxy_id, ok=False)
@@ -371,6 +380,25 @@ async def proxy_list(include_dead: bool = False):
     pool = get_pool()
     infos = await pool.list(include_dead=include_dead)
     return [_to_response(x) for x in infos]
+
+
+@control_plane.get("/debug/proxy_pool_resources")
+async def debug_proxy_pool_resources(include_dead: bool = True):
+    pool = get_pool()
+    infos = await pool.list(include_dead=include_dead)
+    return {
+        "ok": True,
+        "proxies": [
+            {
+                "proxy_id": p.proxy_id,
+                "is_alive": p.is_alive(pool.ttl_s),
+                "last_seen_at": p.last_seen_at,
+                "pool_resource_reported_at": p.pool_resource_reported_at,
+                "pool_resource": dict(p.pool_resource) if p.pool_resource is not None else None,
+            }
+            for p in infos
+        ],
+    }
 
 # -------------------
 # --- KDN-side methods ---

--- a/scheduler/resource/proxy_pool.py
+++ b/scheduler/resource/proxy_pool.py
@@ -75,6 +75,8 @@ class ProxyInfo:
     # Timestamps: registration time and last heartbeat time
     registered_at: float = field(default_factory=lambda: time.time())
     last_seen_at: float = field(default_factory=lambda: time.time())
+    pool_resource: Optional[Dict[str, Any]] = None
+    pool_resource_reported_at: Optional[float] = None
 
     def touch(self) -> None:
         """Refresh last_seen_at when a heartbeat/update is received."""
@@ -124,6 +126,9 @@ class ProxyPool:
 
             # Keep the first registration time; use the newest values for other fields
             info.registered_at = old.registered_at
+            if info.pool_resource is None:
+                info.pool_resource = old.pool_resource
+                info.pool_resource_reported_at = old.pool_resource_reported_at
             self._data[info.proxy_id] = info
 
     async def heartbeat(
@@ -131,6 +136,7 @@ class ProxyPool:
         proxy_id: str,
         load: Optional[ProxyLoad] = None,
         meta_patch: Optional[Dict[str, Any]] = None,
+        pool_resource: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """
         Proxy heartbeat.
@@ -149,6 +155,9 @@ class ProxyPool:
                 p.load.gpu_util = float(load.gpu_util)
             if meta_patch:
                 p.meta.update(dict(meta_patch))
+            if pool_resource is not None:
+                p.pool_resource = dict(pool_resource)
+                p.pool_resource_reported_at = time.time()
             return True
 
     async def remove(self, proxy_id: str) -> None:


### PR DESCRIPTION
### Motivation
- Provide observable, compact pool-level Instance resource summaries so the Scheduler can see Proxy-side instance health and capacity for debugging and future strategies without changing routing semantics.
- Enable Proxy → Scheduler reporting of aggregated metrics (freshness, load, utilization, admission state) to support research-driven scheduling and experiments referenced by Issue #107.

### Description
- Add `InstancePool.build_pool_resource_snapshot(...)` to aggregate per-instance snapshots into a compact `pool_resource` document including liveness, freshness, inflight/QPS sums, utilization summaries, and `pool_admission_state`.
- Expose a Proxy control-plane debug endpoint `GET /debug/pool_resource` and attach `pool_resource` to Scheduler register and heartbeat payloads via the `SchedulerControlClient` and Proxy heartbeat loop (`pool_resource` optional field).
- Extend Scheduler control-plane types and `ProxyPool` to accept and store `pool_resource` and `pool_resource_reported_at`, expose them in `GET /v1/proxy/list` responses, and add `GET /debug/proxy_pool_resources` for Scheduler-side visibility.
- Add lightweight context plumbing: `p_control_plane.set_pool_resource_context(...)` in Proxy startup to populate default `proxy_id`/capacity for local debug endpoint and include `pool_resource` on register/heartbeat calls, keeping all additions optional and backward compatible.
- Files changed: `proxy/resource/instance_pool.py`, `proxy/resource/p_control_plane.py`, `proxy/proxy.py`, `proxy/sclient/scheduler_client.py`, `scheduler/resource/control_plane.py`, `scheduler/resource/proxy_pool.py`, and `README.md` (workflow docs update).

### Testing
- Compiled affected modules with `python3 -m py_compile proxy/resource/instance_pool.py proxy/resource/p_control_plane.py proxy/proxy.py proxy/sclient/scheduler_client.py scheduler/scheduler.py scheduler/resource/*.py` and it succeeded.
- Performed a smoke test by importing `InstancePool` and exercising `build_pool_resource_snapshot(...)` to validate counts, inflight aggregation, GPU memory ratio and `pool_admission_state`; the test succeeded (`pool_resource ok`).
- Ran `git diff --check` and basic repository consistency checks; no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56e1f5af388320a37fb624e086fe85)