### PR TITLE
Report coarse Proxy `pool_resource` summaries to Scheduler and add pool/queue snapshot tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ The frontend URLs above assume a single-machine demo with loopback addresses. In
 3. The Proxy predicts the cost of text-based and KVCache-based injection.
 4. The KDN Server injects reusable KVCache blocks when KVCache reuse is selected.
 5. The Instance forwards the request to vLLM + LMCache and returns the response.
-6. Optionally, the Proxy UI and Instance Resource Dashboard visualize control-plane and resource state for debugging and validation.
+6. Instance resource snapshots can flow through the Proxy control plane, where the Proxy aggregates a compact `pool_resource` snapshot and reports it to the Scheduler through register/heartbeat payloads. The Scheduler stores this state for debug visibility without changing routing decisions.
+7. Optionally, the Proxy UI and Instance Resource Dashboard visualize control-plane and resource state for debugging and validation.
 
 ---
 
@@ -139,6 +140,10 @@ pip install -r requirements.txt
 ```
 
 For the recommended Docker-based environment, see [`env/README.md`](env/README.md). The CacheRoute Dockerfile installs Rust and Tkinter for the optional Instance Resource Agent/Dashboard.
+
+### Resource metric hierarchy
+
+Scheduler-facing Proxy `pool_resource` reports use coarse pool-level summaries only. Detailed per-Instance and per-task metrics stay Proxy-local for debugging and future Proxy-side decisions. For Scheduler-facing fields, `0` means a measured zero and `null` means unavailable, unwired, or insufficient source data. See [`doc/resource_metric_hierarchy.md`](doc/resource_metric_hierarchy.md) for the current metric source audit, source/quality metadata contract, and validation commands.
 
 ---
 

--- a/doc/resource_metric_hierarchy.md
+++ b/doc/resource_metric_hierarchy.md
@@ -1,0 +1,51 @@
+# Resource metric hierarchy and Scheduler pool-resource contract
+
+Issue #110 keeps Scheduler routing unchanged and clarifies which Proxy pool metrics are safe to report upward. The guiding rule is:
+
+- Proxy may keep detailed per-Instance and queue state for local debugging and future local selection.
+- Scheduler receives only compact Proxy-pool summaries and stores them for visibility.
+- `0` means a metric was measured as zero. `null` means the metric is unavailable, unwired, or lacks enough source data.
+
+## Scheduler-facing `pool_resource` fields
+
+| Field | Source | Classification | Scheduler semantics |
+|---|---|---|---|
+| `instances.total` | `InstancePool` registered item count | runtime-maintained counter | Total known Instances, alive or stale. |
+| `instances.alive` | `InstancePool.last_seen_at` + TTL | derived runtime state | Alive Instances only. |
+| `instances.stale` | `InstancePool.last_seen_at` + TTL | derived runtime state | Registered but TTL-expired Instances. |
+| `instances.with_resource` | `InstanceResource.raw_resource` / `resource_reported_at` | derived from measured data | Alive Instances that have at least one resource snapshot. |
+| `instances.missing_resource` | alive minus with-resource | derived from measured data | Alive Instances without resource snapshots. |
+| `load.inflight_total` | `InstanceLoad.inflight` | runtime-maintained counter when heartbeat supplies it; otherwise unavailable | `null` until Instance heartbeat reports inflight. |
+| `load.qps_1m_total` | `InstanceLoad.qps_1m` | runtime-maintained counter when heartbeat supplies it; otherwise unavailable | `null` until Instance heartbeat reports QPS. |
+| `load.load_ratio` | `inflight_total / capacity` | derived from source metrics | `null` when inflight or capacity is unavailable. |
+| `load.capacity` | `PROXY_MAX_CAPACITY` | static configured value | `null` when unset or non-positive. |
+| `load.prepare_queue_depth` | `QueueManager` prepare queue sizes | runtime-maintained counter | Coarse Proxy-level total, not per-Instance detail. |
+| `load.ready_queue_depth` | `QueueManager` ready queue sizes | runtime-maintained counter | Coarse Proxy-level total, not per-Instance detail. |
+| `load.queue_pressure` | queue depth divided by capacity | derived from source metrics | `null` when queue depth or capacity is unavailable. |
+| `utilization.cpu_avg/max` | Instance resource snapshots | real-time measured by lower resource reports | `null` when no resource snapshot contains CPU data. |
+| `utilization.memory_*` | Instance resource snapshots | real-time measured by lower resource reports | Aggregated pool-level ratios only. |
+| `utilization.gpu_util_*` | Instance resource snapshots | real-time measured by lower resource reports | Scheduler uses resource-derived GPU utilization, not placeholder heartbeat GPU load. |
+| `utilization.gpu_mem_*` | Instance resource snapshots | real-time measured by lower resource reports | Aggregated pool-level ratios only. |
+| `utilization.network_*` | Instance resource snapshots | real-time measured by lower resource reports | Total RX/TX only when at least one resource report contains the value. |
+| `health.resource_freshness_s_*` | `resource_reported_at` | derived from measured data | Shows age of resource snapshots. |
+| `health.pool_admission_state` | resource snapshot `capacity_hint.admission_state` | derived from lower-layer admission hints | Coarse state: `accepting`, `degraded`, or `rejecting`. |
+| `metric_source` | Proxy aggregation logic | diagnostic metadata | Identifies the active source or `unavailable`. |
+| `metric_quality` | Proxy aggregation logic | diagnostic metadata | Indicates `complete`, `partial`, or `missing`. |
+
+## Metrics that remain Proxy-local
+
+The Scheduler-facing summary intentionally excludes raw per-Instance resource payloads, per-task trace fields, predictor internals, and per-Instance queue rows. Those details remain available through Proxy debug APIs such as `/v1/instance/list`, `/debug/instance_resources`, and `/debug/pool_resource_sources`.
+
+## Validation checklist
+
+1. Inspect Proxy-local aggregation:
+   ```bash
+   curl -sS http://127.0.0.1:8002/debug/pool_resource | python3 -m json.tool
+   curl -sS http://127.0.0.1:8002/debug/pool_resource_sources | python3 -m json.tool
+   ```
+2. Inspect Scheduler storage:
+   ```bash
+   curl -sS http://127.0.0.1:7002/debug/proxy_pool_resources | python3 -m json.tool
+   ```
+3. Confirm missing metrics are `null` and marked `unavailable`, not silently reported as measured zero.
+4. Confirm Scheduler routing behavior is unchanged; these fields are stored and exposed only.

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -94,6 +94,19 @@ async def _build_proxy_topology_meta() -> Dict[str, Any]:
     return {"kdn_links": merged_links} if merged_links else {}
 
 
+def _build_pool_resource_snapshot(app: FastAPI) -> Dict[str, Any]:
+    pool: InstancePool = app.state.instance_pool  # type: ignore
+    queue_snapshot = queue_mgr.queue_snapshot()
+    return pool.build_pool_resource_snapshot(
+        proxy_id=PROXY_ID,
+        capacity=PROXY_MAX_CAPACITY,
+        prepare_queue_depth=queue_snapshot.get("prepare_queue_depth"),
+        ready_queue_depth=queue_snapshot.get("ready_queue_depth"),
+        active_prepare=queue_snapshot.get("active_prepare"),
+        active_ready=queue_snapshot.get("active_ready"),
+    )
+
+
 def _squelch_noisy_loggers():
     # http client
     logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -122,6 +135,7 @@ async def lifespan(app: FastAPI):
     ttl_s = int(os.environ.get("PROXY_INSTANCE_TTL_S", config.INSTANCE_ALIVE_TTL_S))
     app.state.instance_pool = InstancePool(ttl_s=ttl_s)  # type: ignore
     p_control_plane.set_pool(app.state.instance_pool)  # type: ignore
+    p_control_plane.set_pool_resource_context(PROXY_ID, PROXY_MAX_CAPACITY)
 
     # --- Load the proxy scheduling strategy for the data plane ---
     strategy_name = os.environ.get("PROXY_INSTANCE_STRATEGY", "round_robin")
@@ -190,6 +204,7 @@ async def lifespan(app: FastAPI):
             instance_count=PROXY_INSTANCE_COUNT,
             kv_mem_per_instance_gb=PROXY_KV_MEM_PER_INSTANCE_GB,
             kv_cache_update_policy=PROXY_KV_CACHE_UPDATE_POLICY,
+            pool_resource=_build_pool_resource_snapshot(app),
         )
         # Override the local default heartbeat interval with the interval suggested by the scheduler
         interval = float(reg.heartbeat_interval_s) if reg.heartbeat_interval_s else PROXY_HEARTBEAT_S
@@ -209,6 +224,7 @@ async def lifespan(app: FastAPI):
                 await client.heartbeat(
                     proxy_id=PROXY_ID,
                     meta_patch=await _build_proxy_topology_meta(),
+                    pool_resource=_build_pool_resource_snapshot(app),
                 )
                 await reporter.record(ok=True)
             except Exception as e:

--- a/proxy/queue/instance_queues.py
+++ b/proxy/queue/instance_queues.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Any, Dict
 
 from .task import ProxyTask
 
@@ -44,6 +44,35 @@ class PerInstanceQueueMap:
                 prepare_sem=asyncio.Semaphore(self._prepare_concurrency_per_instance)
             )
         return self._m[instance_id]
+
+
+    def snapshot(self) -> Dict[str, Any]:
+        instances = []
+        prepare_depth = 0
+        ready_depth = 0
+        active_prepare = 0
+        active_ready = 0
+        for instance_id, q in self._m.items():
+            pd = q.prepare_q.qsize()
+            rd = q.ready_q.qsize()
+            prepare_depth += pd
+            ready_depth += rd
+            active_prepare += int(q.active_prepare)
+            active_ready += int(q.active_ready)
+            instances.append({
+                "instance_id": instance_id,
+                "prepare_queue_depth": pd,
+                "ready_queue_depth": rd,
+                "active_prepare": int(q.active_prepare),
+                "active_ready": int(q.active_ready),
+            })
+        return {
+            "prepare_queue_depth": prepare_depth,
+            "ready_queue_depth": ready_depth,
+            "active_prepare": active_prepare,
+            "active_ready": active_ready,
+            "instances": instances,
+        }
 
     @property
     def ready_concurrency_per_instance(self) -> int:

--- a/proxy/queue/manager.py
+++ b/proxy/queue/manager.py
@@ -97,6 +97,13 @@ class QueueManager:
             self._text_bypass_max_per_flush,
         )
 
+
+    def queue_snapshot(self) -> Dict[str, Any]:
+        """Return coarse queue counters for Proxy-level resource reporting."""
+        snap = self._qmap.snapshot()
+        snap["source"] = "proxy_queue_manager"
+        return snap
+
     def _get_kdn_kv_link_lock(self, link_key: str) -> asyncio.Lock:
         lock = self._kdn_kv_link_locks.get(link_key)
         if lock is None:

--- a/proxy/resource/instance_pool.py
+++ b/proxy/resource/instance_pool.py
@@ -144,6 +144,136 @@ class InstancePool:
             it.resource = _resource_from_snapshot(snapshot=snapshot, reported_at=now, metadata=metadata or {})
             return True
 
+
+    def build_pool_resource_snapshot(
+        self,
+        proxy_id: str,
+        capacity: int = 0,
+        prepare_queue_depth: Optional[int] = None,
+        ready_queue_depth: Optional[int] = None,
+        active_prepare: Optional[int] = None,
+        active_ready: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Build a compact Proxy pool-level resource snapshot for Scheduler reporting."""
+        now = time.time()
+        with self._lock:
+            items = list(self._items.values())
+
+        alive_items: List[InstanceInfo] = []
+        stale = 0
+        for it in items:
+            if (now - float(it.last_seen_at)) <= self._ttl_s:
+                alive_items.append(it)
+            else:
+                stale += 1
+
+        reporting = [it for it in alive_items if _has_resource(it.resource)]
+        freshness = [max(0.0, now - float(it.resource.resource_reported_at or now)) for it in reporting]
+
+        admission_counts = {"accepting": 0, "degraded": 0, "rejecting": 0}
+        for it in reporting:
+            state = (it.resource.admission_state or "").strip().lower()
+            if state in admission_counts:
+                admission_counts[state] += 1
+
+        missing_resource = max(0, len(alive_items) - len(reporting))
+        inflight_values = [int(it.load.inflight) for it in alive_items if it.load.inflight is not None]
+        qps_values = [float(it.load.qps_1m) for it in alive_items if it.load.qps_1m is not None]
+        inflight_total = sum(inflight_values) if inflight_values else None
+        qps_1m_total = sum(qps_values) if qps_values else None
+        effective_capacity = int(capacity or 0) if int(capacity or 0) > 0 else None
+        queue_work = (int(prepare_queue_depth or 0) + int(ready_queue_depth or 0)) if prepare_queue_depth is not None or ready_queue_depth is not None else None
+        load_ratio = (float(inflight_total) / float(effective_capacity)) if inflight_total is not None and effective_capacity else None
+        queue_pressure = (float(queue_work) / float(effective_capacity)) if queue_work is not None and effective_capacity else None
+
+        cpu_values = [float(it.resource.cpu_util) for it in reporting if it.resource.cpu_util is not None]
+        gpu_values = [float(it.resource.gpu_util_avg) for it in reporting if it.resource.gpu_util_avg is not None]
+        mem_used = sum(float(it.resource.memory_used_mb or 0.0) for it in reporting)
+        mem_total = sum(float(it.resource.memory_total_mb or 0.0) for it in reporting)
+        gpu_mem_used = sum(float(it.resource.gpu_mem_used_mb or 0.0) for it in reporting)
+        gpu_mem_total = sum(float(it.resource.gpu_mem_total_mb or 0.0) for it in reporting)
+        mem_free_ratios = [float(it.resource.memory_free_ratio) for it in reporting if it.resource.memory_free_ratio is not None]
+        rx_total = sum(float(it.resource.network_rx_mbps or 0.0) for it in reporting if it.resource.network_rx_mbps is not None)
+        tx_total = sum(float(it.resource.network_tx_mbps or 0.0) for it in reporting if it.resource.network_tx_mbps is not None)
+        has_rx = any(it.resource.network_rx_mbps is not None for it in reporting)
+        has_tx = any(it.resource.network_tx_mbps is not None for it in reporting)
+
+        if len(alive_items) == 0:
+            pool_state = "rejecting"
+        elif reporting and admission_counts["rejecting"] == len(reporting) and missing_resource == 0:
+            pool_state = "rejecting"
+        elif admission_counts["degraded"] or admission_counts["rejecting"] or missing_resource:
+            pool_state = "degraded"
+        else:
+            pool_state = "accepting"
+
+        return {
+            "schema_version": 1,
+            "proxy_id": proxy_id,
+            "generated_at": now,
+            "ttl_s": self._ttl_s,
+            "resource_freshness_s": _min_avg_max(freshness),
+            "instances": {
+                "total": len(items),
+                "alive": len(alive_items),
+                "stale": stale,
+                "with_resource": len(reporting),
+                "missing_resource": missing_resource,
+                "accepting": admission_counts["accepting"],
+                "degraded": admission_counts["degraded"],
+                "rejecting": admission_counts["rejecting"],
+            },
+            "load": {
+                "inflight_total": inflight_total,
+                "qps_1m_total": qps_1m_total,
+                "load_ratio": load_ratio,
+                "capacity": effective_capacity,
+                "prepare_queue_depth": prepare_queue_depth,
+                "ready_queue_depth": ready_queue_depth,
+                "active_prepare": active_prepare,
+                "active_ready": active_ready,
+                "queue_pressure": queue_pressure,
+            },
+            "utilization": {
+                "cpu_avg": _avg(cpu_values),
+                "cpu_max": max(cpu_values) if cpu_values else None,
+                "memory_used_mb": mem_used if reporting else None,
+                "memory_total_mb": mem_total if reporting else None,
+                "memory_used_ratio": _ratio(mem_used, mem_total),
+                "memory_free_ratio_min": min(mem_free_ratios) if mem_free_ratios else None,
+                "gpu_util_avg": _avg(gpu_values),
+                "gpu_util_max": max(gpu_values) if gpu_values else None,
+                "gpu_mem_used_mb": gpu_mem_used if reporting else None,
+                "gpu_mem_total_mb": gpu_mem_total if reporting else None,
+                "gpu_mem_used_ratio": _ratio(gpu_mem_used, gpu_mem_total),
+                "network_rx_mbps_total": rx_total if has_rx else None,
+                "network_tx_mbps_total": tx_total if has_tx else None,
+            },
+            "health": {
+                "resource_freshness_s_avg": _avg(freshness),
+                "resource_freshness_s_max": max(freshness) if freshness else None,
+                "pool_admission_state": pool_state,
+                "data_quality": _data_quality(alive=len(alive_items), reporting=len(reporting)),
+            },
+            "metric_source": _pool_resource_metric_source(
+                has_instance_inflight=bool(inflight_values),
+                has_instance_qps=bool(qps_values),
+                has_resource=bool(reporting),
+                has_queue=prepare_queue_depth is not None or ready_queue_depth is not None,
+                has_capacity=effective_capacity is not None,
+            ),
+            "metric_quality": {
+                "resource": _data_quality(alive=len(alive_items), reporting=len(reporting)),
+                "load": "partial" if inflight_total is not None or qps_1m_total is not None else "missing",
+                "queue": "complete" if prepare_queue_depth is not None and ready_queue_depth is not None else "missing",
+            },
+            "pool_admission_state": pool_state,
+            "pool_admission_reason": (
+                f"{admission_counts['accepting']} accepting, {admission_counts['degraded']} degraded, "
+                f"{admission_counts['rejecting']} rejecting, {len(alive_items)} alive"
+            ),
+        }
+
     def remove(self, instance_id: str) -> bool:
         with self._lock:
             return self._items.pop(instance_id, None) is not None
@@ -161,6 +291,73 @@ class InstancePool:
             if (now - int(it.last_seen_at)) <= self._ttl_s:
                 alive.append(it)
         return alive
+
+
+def _has_resource(resource: InstanceResource) -> bool:
+    return bool(resource.raw_resource) and resource.resource_reported_at is not None
+
+
+def _avg(values: List[float]) -> Optional[float]:
+    return (sum(values) / len(values)) if values else None
+
+
+def _min_avg_max(values: List[float]) -> Dict[str, Optional[float]]:
+    if not values:
+        return {"min": None, "avg": None, "max": None}
+    return {"min": min(values), "avg": sum(values) / len(values), "max": max(values)}
+
+
+def _ratio(used: float, total: float) -> Optional[float]:
+    return (used / total) if total > 0 else None
+
+
+def _data_quality(alive: int, reporting: int) -> str:
+    if alive <= 0 or reporting <= 0:
+        return "missing"
+    if reporting == alive:
+        return "complete"
+    return "partial"
+
+
+def _pool_resource_metric_source(
+    has_instance_inflight: bool,
+    has_instance_qps: bool,
+    has_resource: bool,
+    has_queue: bool,
+    has_capacity: bool,
+) -> Dict[str, str]:
+    return {
+        "instances": "instance_pool",
+        "inflight_total": "instance_heartbeat" if has_instance_inflight else "unavailable",
+        "qps_1m_total": "instance_heartbeat" if has_instance_qps else "unavailable",
+        "load_ratio": "derived_from_inflight_and_capacity" if has_instance_inflight and has_capacity else "unavailable",
+        "capacity": "proxy_config" if has_capacity else "unavailable",
+        "queue_depth": "proxy_queue_manager" if has_queue else "unavailable",
+        "queue_pressure": "derived_from_queue_depth_and_capacity" if has_queue and has_capacity else "unavailable",
+        "resource": "instance_resource_snapshot" if has_resource else "unavailable",
+        "pool_admission_state": "derived_from_instance_admission_state" if has_resource else "unavailable",
+    }
+
+
+def build_pool_resource_sources() -> Dict[str, Any]:
+    return {
+        "null_vs_zero": "0 means measured zero; null means unavailable, unwired, or not enough source data.",
+        "scheduler_granularity": "Scheduler receives coarse Proxy-pool summaries only; per-instance raw resources stay in Proxy debug APIs.",
+        "fields": {
+            "instances.total/alive/stale": "runtime-maintained InstancePool membership and TTL state",
+            "instances.with_resource/missing_resource": "derived from Instance resource snapshot presence",
+            "load.inflight_total": "sum of InstanceLoad.inflight only when Instance heartbeats report it; otherwise null",
+            "load.qps_1m_total": "sum of InstanceLoad.qps_1m only when Instance heartbeats report it; otherwise null",
+            "load.load_ratio": "derived from measured inflight_total and configured capacity; otherwise null",
+            "load.capacity": "configured Proxy max capacity; null when unset or non-positive",
+            "load.prepare_queue_depth/ready_queue_depth": "Proxy QueueManager qsize totals when available; otherwise null",
+            "load.queue_pressure": "derived from queue depth and configured capacity; otherwise null",
+            "utilization.*": "derived from Instance resource snapshots; null when no resource report has that metric",
+            "health.resource_freshness_s_*": "derived from resource_reported_at timestamps",
+            "health.pool_admission_state": "derived from resource snapshot capacity_hint.admission_state",
+            "metric_source/metric_quality": "diagnostic provenance for Scheduler consumers",
+        },
+    }
 
 
 def _as_float(value: Any) -> Optional[float]:

--- a/proxy/resource/p_control_plane.py
+++ b/proxy/resource/p_control_plane.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from typing import Any, Dict, List, Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from .instance_pool import InstancePool
+from .instance_pool import InstancePool, build_pool_resource_sources
 
 import logging
 logger = logging.getLogger("proxy.p_control_plane")
@@ -23,11 +24,19 @@ _instance_kdn_links: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _kdn_links_lock = asyncio.Lock()
 _resource_snapshot_seen: set[str] = set()
 _unknown_resource_warn_at: Dict[str, float] = {}
+_proxy_id: str = os.environ.get("PROXY_ID", "unknown")
+_proxy_capacity: int = int(os.environ.get("PROXY_MAX_CAPACITY", "0") or 0)
 
 
 def set_pool(pool: InstancePool) -> None:
     global _pool
     _pool = pool
+
+
+def set_pool_resource_context(proxy_id: str, capacity: int = 0) -> None:
+    global _proxy_id, _proxy_capacity
+    _proxy_id = proxy_id
+    _proxy_capacity = int(capacity or 0)
 
 
 def get_pool() -> InstancePool:
@@ -251,6 +260,17 @@ async def list_instances(include_dead: bool = False) -> List[Dict[str, Any]]:
     return out
 
 
+
+
+@_control_plane.get("/debug/pool_resource")
+async def debug_pool_resource() -> Dict[str, Any]:
+    pool = get_pool()
+    return {"ok": True, "pool_resource": pool.build_pool_resource_snapshot(proxy_id=_proxy_id, capacity=_proxy_capacity)}
+
+
+@_control_plane.get("/debug/pool_resource_sources")
+async def debug_pool_resource_sources() -> Dict[str, Any]:
+    return {"ok": True, "sources": build_pool_resource_sources()}
 
 
 @_control_plane.get("/debug/instance_resources")

--- a/proxy/sclient/scheduler_client.py
+++ b/proxy/sclient/scheduler_client.py
@@ -43,6 +43,7 @@ class SchedulerControlClient:
         instance_count: int = 0,
         kv_mem_per_instance_gb: float = 0.0,
         kv_cache_update_policy: str = "lru",
+        pool_resource: Optional[Dict[str, Any]] = None,
     ) -> RegisterResult:
         payload = {
             "proxy_id": proxy_id,
@@ -57,6 +58,8 @@ class SchedulerControlClient:
             "kv_mem_per_instance_gb": kv_mem_per_instance_gb,
             "kv_cache_update_policy": kv_cache_update_policy,
         }
+        if pool_resource is not None:
+            payload["pool_resource"] = pool_resource
         r = await self._client.post(f"{self.base_url}/v1/proxy/register", json=payload)
         r.raise_for_status()
         j = r.json()
@@ -73,6 +76,7 @@ class SchedulerControlClient:
         qps_1m: Optional[float] = None,
         gpu_util: Optional[float] = None,
         meta_patch: Optional[Dict[str, Any]] = None,
+        pool_resource: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {"proxy_id": proxy_id}
         # Include values only when present to avoid triggering server-side full overwrite to 0
@@ -84,6 +88,8 @@ class SchedulerControlClient:
             payload["gpu_util"] = gpu_util
         if meta_patch:
             payload["meta_patch"] = meta_patch
+        if pool_resource is not None:
+            payload["pool_resource"] = pool_resource
 
         r = await self._client.post(f"{self.base_url}/v1/proxy/heartbeat", json=payload)
         r.raise_for_status()

--- a/scheduler/resource/control_plane.py
+++ b/scheduler/resource/control_plane.py
@@ -19,6 +19,7 @@ Note:
 from __future__ import annotations
 
 import os
+import time
 # import time
 import uuid
 import asyncio
@@ -69,6 +70,7 @@ class ProxyRegisterRequest(BaseModel):
     instance_count: int = Field(default=0, ge=0)
     kv_mem_per_instance_gb: float = Field(default=0.0, ge=0.0)
     kv_cache_update_policy: str = Field(default="lru")
+    pool_resource: Optional[Dict[str, Any]] = None
 
 class ProxyRegisterResponse(BaseModel):
     """
@@ -94,6 +96,7 @@ class ProxyHeartbeatRequest(BaseModel):
     qps_1m: Optional[float] = None
     gpu_util: Optional[float] = None
     meta_patch: Optional[Dict[str, Any]] = None
+    pool_resource: Optional[Dict[str, Any]] = None
 
 
 class ProxyUnregisterRequest(BaseModel):
@@ -126,6 +129,8 @@ class ProxyInfoResponse(BaseModel):
     registered_at: float
     last_seen_at: float
     is_alive: bool
+    pool_resource: Optional[Dict[str, Any]] = None
+    pool_resource_reported_at: Optional[float] = None
 
 
 class KDNRegisterRequest(BaseModel):
@@ -263,6 +268,8 @@ def _to_response(info: ProxyInfo) -> ProxyInfoResponse:
         registered_at=float(info.registered_at),
         last_seen_at=float(info.last_seen_at),
         is_alive=info.is_alive(pool.ttl_s),
+        pool_resource=dict(info.pool_resource) if info.pool_resource is not None else None,
+        pool_resource_reported_at=info.pool_resource_reported_at,
     )
 
 
@@ -299,6 +306,8 @@ async def proxy_register(req: ProxyRegisterRequest):
                        kv_mem_per_instance_gb=float(req.kv_mem_per_instance_gb or 0.0),
                        kv_cache_pool_gb=float(inst_cnt) * float(kv_gb),
                        ),  # Registration starts with an empty load; heartbeats update it later
+        pool_resource=dict(req.pool_resource) if req.pool_resource is not None else None,
+        pool_resource_reported_at=time.time() if req.pool_resource is not None else None,
     )
     # Registration is essentially an upsert
     pool = get_pool()
@@ -334,7 +343,7 @@ async def proxy_heartbeat(req: ProxyHeartbeatRequest):
         )
 
     pool = get_pool()
-    ok = await pool.heartbeat(req.proxy_id, load=load, meta_patch=req.meta_patch)
+    ok = await pool.heartbeat(req.proxy_id, load=load, meta_patch=req.meta_patch, pool_resource=req.pool_resource)
     if not ok:
         # Failure: output immediately and count it as an error
         await _hb_agg.record_proxy(req.proxy_id, ok=False)
@@ -371,6 +380,25 @@ async def proxy_list(include_dead: bool = False):
     pool = get_pool()
     infos = await pool.list(include_dead=include_dead)
     return [_to_response(x) for x in infos]
+
+
+@control_plane.get("/debug/proxy_pool_resources")
+async def debug_proxy_pool_resources(include_dead: bool = True):
+    pool = get_pool()
+    infos = await pool.list(include_dead=include_dead)
+    return {
+        "ok": True,
+        "proxies": [
+            {
+                "proxy_id": p.proxy_id,
+                "is_alive": p.is_alive(pool.ttl_s),
+                "last_seen_at": p.last_seen_at,
+                "pool_resource_reported_at": p.pool_resource_reported_at,
+                "pool_resource": dict(p.pool_resource) if p.pool_resource is not None else None,
+            }
+            for p in infos
+        ],
+    }
 
 # -------------------
 # --- KDN-side methods ---

--- a/scheduler/resource/proxy_pool.py
+++ b/scheduler/resource/proxy_pool.py
@@ -75,6 +75,8 @@ class ProxyInfo:
     # Timestamps: registration time and last heartbeat time
     registered_at: float = field(default_factory=lambda: time.time())
     last_seen_at: float = field(default_factory=lambda: time.time())
+    pool_resource: Optional[Dict[str, Any]] = None
+    pool_resource_reported_at: Optional[float] = None
 
     def touch(self) -> None:
         """Refresh last_seen_at when a heartbeat/update is received."""
@@ -124,6 +126,9 @@ class ProxyPool:
 
             # Keep the first registration time; use the newest values for other fields
             info.registered_at = old.registered_at
+            if info.pool_resource is None:
+                info.pool_resource = old.pool_resource
+                info.pool_resource_reported_at = old.pool_resource_reported_at
             self._data[info.proxy_id] = info
 
     async def heartbeat(
@@ -131,6 +136,7 @@ class ProxyPool:
         proxy_id: str,
         load: Optional[ProxyLoad] = None,
         meta_patch: Optional[Dict[str, Any]] = None,
+        pool_resource: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """
         Proxy heartbeat.
@@ -149,6 +155,9 @@ class ProxyPool:
                 p.load.gpu_util = float(load.gpu_util)
             if meta_patch:
                 p.meta.update(dict(meta_patch))
+            if pool_resource is not None:
+                p.pool_resource = dict(pool_resource)
+                p.pool_resource_reported_at = time.time()
             return True
 
     async def remove(self, proxy_id: str) -> None:


### PR DESCRIPTION
### Motivation

- Allow the Proxy to report compact, scheduler-facing pool-level resource summaries (`pool_resource`) so the Scheduler can store and expose Proxy resource state for visibility without affecting routing decisions.
- Keep detailed per-Instance and per-task metrics Proxy-local while providing provenance and data-quality metadata for Scheduler consumers.
- Document the metric hierarchy and validation commands so operators can inspect and audit reported fields.

### Description

- Added Proxy-side pool snapshot construction via `InstancePool.build_pool_resource_snapshot` and a helper `_build_pool_resource_snapshot` in `proxy/proxy.py`, and wired `pool_resource` into `register` and periodic `heartbeat` payloads. 
- Implemented queue-level introspection with `PerInstanceQueueMap.snapshot` and `QueueManager.queue_snapshot`, and included these queue counters in the pool snapshot inputs. 
- Extended `proxy/resource/p_control_plane.py` with `set_pool_resource_context`, debug endpoints `/debug/pool_resource` and `/debug/pool_resource_sources`, and environment-backed defaults for proxy id/capacity. 
- Extended scheduler APIs and models to accept and store `pool_resource` on proxy `register` and `heartbeat`, added `debug/proxy_pool_resources`, and persisted `pool_resource` and `pool_resource_reported_at` in `ProxyInfo` (`scheduler/resource/control_plane.py`, `scheduler/resource/proxy_pool.py`).
- Updated the client-side control client to include `pool_resource` in `register`/`heartbeat` requests (`proxy/sclient/scheduler_client.py`).
- Added supporting helpers and provenance logic including `_pool_resource_metric_source`, `_data_quality`, aggregation helpers, and the `doc/resource_metric_hierarchy.md` doc, and updated `README.md` with the new workflow and metric hierarchy notes. 

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56e1f5af388320a37fb624e086fe85)