### PR TITLE
Audit pool_resource metric contract and wire coarse queue depths (Issue #110)

### DIFF
--- a/doc/pool_resource_metrics.md
+++ b/doc/pool_resource_metrics.md
@@ -1,0 +1,59 @@
+# Pool Resource Metric Contract
+
+Issue #110 defines the first Scheduler-facing contract for `pool_resource`.
+The Scheduler stores this snapshot and exposes it for debugging; it must not use
+these fields for routing until a later scheduling strategy explicitly opts in.
+
+## Granularity
+
+Proxy keeps detailed per-Instance state locally in `/v1/instance/list` and
+`/debug/instance_resources`. Scheduler receives only a coarse Proxy-pool summary:
+instance counts, aggregate load, aggregate utilization, pool admission state, and
+metric provenance.
+
+## Null vs zero
+
+For Scheduler-facing fields:
+
+- `0` means a metric source reported a real zero.
+- `null` means the metric is unavailable, not wired, or unknown.
+- Missing fields remain tolerated for backward compatibility.
+
+This prevents downstream policies from treating placeholders as idle capacity.
+
+## Current field audit
+
+| Field | Source | Classification | Scheduler contract |
+| --- | --- | --- | --- |
+| `instances.total` | Proxy `InstancePool` registry | runtime-maintained counter | Reported count. |
+| `instances.alive` | Proxy TTL check using `last_seen_at` | derived from runtime state | Reported count. |
+| `instances.stale` | Proxy TTL check using `last_seen_at` | derived from runtime state | Reported count. |
+| `instances.with_resource` | Instances with accepted resource snapshots | derived from measured data | Reported count. |
+| `instances.missing_resource` | Alive minus resource-reporting instances | derived from measured data | Reported count. |
+| `load.inflight_total` | Optional Instance heartbeat `inflight` | runtime-maintained when supplied; otherwise unavailable | Sum when present, otherwise `null`. |
+| `load.qps_1m_total` | Optional Instance heartbeat `qps_1m` | runtime-maintained when supplied; otherwise unavailable | Sum when present, otherwise `null`. |
+| `load.load_ratio` | `inflight_total / capacity` | derived from load and static config | `null` unless inflight is available and capacity is positive. |
+| `load.capacity` | Proxy `PROXY_MAX_CAPACITY` / register-time config | static configured value | Always reported as configured integer. |
+| `load.prepare_queue_depth` | Proxy `QueueManager` aggregate prepare queue size | runtime-maintained queue counter | Reported when data-plane queue manager is available; otherwise `null`. |
+| `load.ready_queue_depth` | Proxy `QueueManager` aggregate ready queue size | runtime-maintained queue counter | Reported when data-plane queue manager is available; otherwise `null`. |
+| `load.queue_pressure` | queue depth divided by capacity | derived from queue counters and static config | `null` unless queue depth and capacity are available. |
+| `utilization.cpu_avg/max` | Instance resource-agent snapshots | real-time measured snapshot aggregate | `null` when no resource snapshots exist. |
+| `utilization.memory_*` | Instance resource-agent snapshots | real-time measured snapshot aggregate | `null` when not reported by snapshots. |
+| `utilization.gpu_util_*` | Instance resource-agent GPU snapshots | real-time measured snapshot aggregate | `null` when not reported by snapshots. |
+| `utilization.gpu_mem_*` | Instance resource-agent GPU snapshots | real-time measured snapshot aggregate | `null` when not reported by snapshots. |
+| `utilization.network_*` | Instance resource-agent network snapshots | real-time measured snapshot aggregate | `null` when not reported by snapshots. |
+| `pool_admission_state` | Instance resource snapshot `capacity_hint.admission_state` plus missing-resource state | derived from measured data | Coarse accepting/degraded/rejecting summary. |
+| `resource_freshness_s` | Snapshot receive time in Proxy | derived from measured data | min/avg/max age; all `null` without snapshots. |
+
+## Provenance metadata
+
+Each `pool_resource` includes:
+
+- `metric_source`: field-level source labels such as `instance_resource_snapshot`,
+  `proxy_queue_manager`, `proxy_config`, or `unavailable`.
+- `metric_quality`: coarse `complete`, `partial`, or `missing` labels for
+  resource, load, and queue groups.
+
+Proxy also exposes `/debug/pool_resource_sources` for a compact diagnostic view.
+Scheduler exposes `/debug/proxy_pool_resources` and stores these metadata fields
+without interpreting them.

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -134,6 +134,7 @@ async def lifespan(app: FastAPI):
     app.state.instance_pool = InstancePool(ttl_s=ttl_s)  # type: ignore
     p_control_plane.set_pool(app.state.instance_pool)  # type: ignore
     p_control_plane.set_pool_resource_context(PROXY_ID, PROXY_MAX_CAPACITY)
+    p_control_plane.set_queue_snapshot_provider(lambda: queue_mgr.queue_depth_snapshot())
 
     # --- Load the proxy scheduling strategy for the data plane ---
     strategy_name = os.environ.get("PROXY_INSTANCE_STRATEGY", "round_robin")

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -96,11 +96,12 @@ async def _build_proxy_topology_meta() -> Dict[str, Any]:
 
 def _build_pool_resource_snapshot(app: FastAPI) -> Dict[str, Any]:
     pool: InstancePool = app.state.instance_pool  # type: ignore
+    queue_depths = queue_mgr.queue_depth_snapshot()
     return pool.build_pool_resource_snapshot(
         proxy_id=PROXY_ID,
         capacity=PROXY_MAX_CAPACITY,
-        prepare_queue_depth=None,
-        ready_queue_depth=None,
+        prepare_queue_depth=queue_depths.get("prepare_queue_depth"),
+        ready_queue_depth=queue_depths.get("ready_queue_depth"),
     )
 
 

--- a/proxy/queue/instance_queues.py
+++ b/proxy/queue/instance_queues.py
@@ -45,6 +45,18 @@ class PerInstanceQueueMap:
             )
         return self._m[instance_id]
 
+    def snapshot_depths(self) -> Dict[str, Dict[str, int]]:
+        """Return current per-instance queue depths for coarse pool-level observability."""
+        out: Dict[str, Dict[str, int]] = {}
+        for instance_id, queues in self._m.items():
+            out[instance_id] = {
+                "prepare_queue_depth": int(queues.prepare_q.qsize()),
+                "ready_queue_depth": int(queues.ready_q.qsize()),
+                "active_prepare": int(queues.active_prepare),
+                "active_ready": int(queues.active_ready),
+            }
+        return out
+
     @property
     def ready_concurrency_per_instance(self) -> int:
         return self._ready_concurrency_per_instance

--- a/proxy/queue/manager.py
+++ b/proxy/queue/manager.py
@@ -97,6 +97,22 @@ class QueueManager:
             self._text_bypass_max_per_flush,
         )
 
+
+    def queue_depth_snapshot(self) -> Dict[str, Any]:
+        """Return coarse queue depths without exposing task payloads.
+
+        Scheduler-facing pool_resource uses only the global totals. The per-instance
+        section stays Proxy-local for debugging.
+        """
+        per_instance = self._qmap.snapshot_depths()
+        prepare_total = sum(item["prepare_queue_depth"] for item in per_instance.values())
+        ready_total = sum(item["ready_queue_depth"] for item in per_instance.values())
+        return {
+            "prepare_queue_depth": int(prepare_total),
+            "ready_queue_depth": int(ready_total),
+            "per_instance": per_instance,
+        }
+
     def _get_kdn_kv_link_lock(self, link_key: str) -> asyncio.Lock:
         lock = self._kdn_kv_link_locks.get(link_key)
         if lock is None:

--- a/proxy/resource/instance_pool.py
+++ b/proxy/resource/instance_pool.py
@@ -152,7 +152,11 @@ class InstancePool:
         prepare_queue_depth: Optional[int] = None,
         ready_queue_depth: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Build a compact Proxy pool-level resource snapshot for Scheduler reporting."""
+        """Build a compact Proxy pool-level resource snapshot for Scheduler reporting.
+
+        Null means unavailable/not wired; zero means the metric is actually reported as zero.
+        This keeps Scheduler-side consumers from mistaking placeholders for measured load.
+        """
         now = time.time()
         with self._lock:
             items = list(self._items.values())
@@ -175,22 +179,30 @@ class InstancePool:
                 admission_counts[state] += 1
 
         missing_resource = max(0, len(alive_items) - len(reporting))
-        inflight_total = sum(int(it.load.inflight or 0) for it in alive_items)
-        qps_1m_total = sum(float(it.load.qps_1m or 0.0) for it in alive_items)
+        inflight_values = [int(it.load.inflight) for it in alive_items if it.load.inflight is not None]
+        qps_values = [float(it.load.qps_1m) for it in alive_items if it.load.qps_1m is not None]
+        inflight_total = sum(inflight_values) if inflight_values else None
+        qps_1m_total = sum(qps_values) if qps_values else None
         effective_capacity = int(capacity or 0)
-        load_ratio = inflight_total / max(effective_capacity, 1)
+        load_ratio = _ratio(float(inflight_total), float(effective_capacity)) if inflight_total is not None else None
+        queued_total = None
+        if prepare_queue_depth is not None or ready_queue_depth is not None:
+            queued_total = int(prepare_queue_depth or 0) + int(ready_queue_depth or 0)
+        queue_pressure = _ratio(float(queued_total), float(effective_capacity)) if queued_total is not None else None
 
         cpu_values = [float(it.resource.cpu_util) for it in reporting if it.resource.cpu_util is not None]
         gpu_values = [float(it.resource.gpu_util_avg) for it in reporting if it.resource.gpu_util_avg is not None]
-        mem_used = sum(float(it.resource.memory_used_mb or 0.0) for it in reporting)
-        mem_total = sum(float(it.resource.memory_total_mb or 0.0) for it in reporting)
-        gpu_mem_used = sum(float(it.resource.gpu_mem_used_mb or 0.0) for it in reporting)
-        gpu_mem_total = sum(float(it.resource.gpu_mem_total_mb or 0.0) for it in reporting)
+        mem_used_values = [float(it.resource.memory_used_mb) for it in reporting if it.resource.memory_used_mb is not None]
+        mem_total_values = [float(it.resource.memory_total_mb) for it in reporting if it.resource.memory_total_mb is not None]
+        gpu_mem_used_values = [float(it.resource.gpu_mem_used_mb) for it in reporting if it.resource.gpu_mem_used_mb is not None]
+        gpu_mem_total_values = [float(it.resource.gpu_mem_total_mb) for it in reporting if it.resource.gpu_mem_total_mb is not None]
+        mem_used = sum(mem_used_values) if mem_used_values else None
+        mem_total = sum(mem_total_values) if mem_total_values else None
+        gpu_mem_used = sum(gpu_mem_used_values) if gpu_mem_used_values else None
+        gpu_mem_total = sum(gpu_mem_total_values) if gpu_mem_total_values else None
         mem_free_ratios = [float(it.resource.memory_free_ratio) for it in reporting if it.resource.memory_free_ratio is not None]
-        rx_total = sum(float(it.resource.network_rx_mbps or 0.0) for it in reporting if it.resource.network_rx_mbps is not None)
-        tx_total = sum(float(it.resource.network_tx_mbps or 0.0) for it in reporting if it.resource.network_tx_mbps is not None)
-        has_rx = any(it.resource.network_rx_mbps is not None for it in reporting)
-        has_tx = any(it.resource.network_tx_mbps is not None for it in reporting)
+        rx_values = [float(it.resource.network_rx_mbps) for it in reporting if it.resource.network_rx_mbps is not None]
+        tx_values = [float(it.resource.network_tx_mbps) for it in reporting if it.resource.network_tx_mbps is not None]
 
         if len(alive_items) == 0:
             pool_state = "rejecting"
@@ -201,11 +213,33 @@ class InstancePool:
         else:
             pool_state = "accepting"
 
+        metric_source = {
+            "instances": "proxy_instance_pool_ttl",
+            "resource": "instance_resource_snapshot" if reporting else "unavailable",
+            "inflight_total": "instance_heartbeat" if inflight_values else "unavailable",
+            "qps_1m_total": "instance_heartbeat" if qps_values else "unavailable",
+            "load_ratio": "derived_from_inflight_capacity" if load_ratio is not None else "unavailable",
+            "capacity": "proxy_config",
+            "prepare_queue_depth": "proxy_queue_manager" if prepare_queue_depth is not None else "unavailable",
+            "ready_queue_depth": "proxy_queue_manager" if ready_queue_depth is not None else "unavailable",
+            "queue_pressure": "derived_from_queue_depth_capacity" if queue_pressure is not None else "unavailable",
+            "utilization": "instance_resource_snapshot" if reporting else "unavailable",
+            "pool_admission_state": "derived_from_instance_resource_admission",
+            "resource_freshness_s": "derived_from_instance_resource_report_time" if reporting else "unavailable",
+        }
+        metric_quality = {
+            "resource": _quality(len(reporting), len(alive_items)),
+            "load": _quality(len(inflight_values) + len(qps_values), max(1, len(alive_items) * 2)) if alive_items else "missing",
+            "queue": "complete" if prepare_queue_depth is not None and ready_queue_depth is not None else "missing",
+        }
+
         return {
             "schema_version": 1,
             "proxy_id": proxy_id,
             "generated_at": now,
             "ttl_s": self._ttl_s,
+            "metric_source": metric_source,
+            "metric_quality": metric_quality,
             "resource_freshness_s": _min_avg_max(freshness),
             "instances": {
                 "total": len(items),
@@ -224,21 +258,22 @@ class InstancePool:
                 "capacity": effective_capacity,
                 "prepare_queue_depth": prepare_queue_depth,
                 "ready_queue_depth": ready_queue_depth,
+                "queue_pressure": queue_pressure,
             },
             "utilization": {
                 "cpu_avg": _avg(cpu_values),
                 "cpu_max": max(cpu_values) if cpu_values else None,
-                "memory_used_mb": mem_used if reporting else None,
-                "memory_total_mb": mem_total if reporting else None,
+                "memory_used_mb": mem_used,
+                "memory_total_mb": mem_total,
                 "memory_used_ratio": _ratio(mem_used, mem_total),
                 "memory_free_ratio_min": min(mem_free_ratios) if mem_free_ratios else None,
                 "gpu_util_avg": _avg(gpu_values),
                 "gpu_util_max": max(gpu_values) if gpu_values else None,
-                "gpu_mem_used_mb": gpu_mem_used if reporting else None,
-                "gpu_mem_total_mb": gpu_mem_total if reporting else None,
+                "gpu_mem_used_mb": gpu_mem_used,
+                "gpu_mem_total_mb": gpu_mem_total,
                 "gpu_mem_used_ratio": _ratio(gpu_mem_used, gpu_mem_total),
-                "network_rx_mbps_total": rx_total if has_rx else None,
-                "network_tx_mbps_total": tx_total if has_tx else None,
+                "network_rx_mbps_total": sum(rx_values) if rx_values else None,
+                "network_tx_mbps_total": sum(tx_values) if tx_values else None,
             },
             "pool_admission_state": pool_state,
             "pool_admission_reason": (
@@ -280,8 +315,16 @@ def _min_avg_max(values: List[float]) -> Dict[str, Optional[float]]:
     return {"min": min(values), "avg": sum(values) / len(values), "max": max(values)}
 
 
-def _ratio(used: float, total: float) -> Optional[float]:
-    return (used / total) if total > 0 else None
+def _ratio(used: Optional[float], total: Optional[float]) -> Optional[float]:
+    return (used / total) if used is not None and total is not None and total > 0 else None
+
+
+def _quality(populated: int, expected: int) -> str:
+    if expected <= 0 or populated <= 0:
+        return "missing"
+    if populated >= expected:
+        return "complete"
+    return "partial"
 
 
 def _as_float(value: Any) -> Optional[float]:

--- a/proxy/resource/p_control_plane.py
+++ b/proxy/resource/p_control_plane.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -26,6 +26,7 @@ _resource_snapshot_seen: set[str] = set()
 _unknown_resource_warn_at: Dict[str, float] = {}
 _proxy_id: str = os.environ.get("PROXY_ID", "unknown")
 _proxy_capacity: int = int(os.environ.get("PROXY_MAX_CAPACITY", "0") or 0)
+_queue_snapshot_provider: Optional[Callable[[], Dict[str, Any]]] = None
 
 
 def set_pool(pool: InstancePool) -> None:
@@ -37,6 +38,34 @@ def set_pool_resource_context(proxy_id: str, capacity: int = 0) -> None:
     global _proxy_id, _proxy_capacity
     _proxy_id = proxy_id
     _proxy_capacity = int(capacity or 0)
+
+
+def set_queue_snapshot_provider(provider: Optional[Callable[[], Dict[str, Any]]]) -> None:
+    """Register a lazy queue-depth provider without coupling control plane to QueueManager."""
+    global _queue_snapshot_provider
+    _queue_snapshot_provider = provider
+
+
+def _build_pool_resource_snapshot() -> Dict[str, Any]:
+    pool = get_pool()
+    prepare_queue_depth = None
+    ready_queue_depth = None
+    if _queue_snapshot_provider is not None:
+        try:
+            queue_depths = _queue_snapshot_provider() or {}
+            prepare_queue_depth = queue_depths.get("prepare_queue_depth")
+            ready_queue_depth = queue_depths.get("ready_queue_depth")
+        except Exception:
+            logger.warning(
+                "[ProxyCP] queue snapshot provider failed; queue metrics unavailable",
+                exc_info=True,
+            )
+    return pool.build_pool_resource_snapshot(
+        proxy_id=_proxy_id,
+        capacity=_proxy_capacity,
+        prepare_queue_depth=prepare_queue_depth,
+        ready_queue_depth=ready_queue_depth,
+    )
 
 
 def get_pool() -> InstancePool:
@@ -264,14 +293,12 @@ async def list_instances(include_dead: bool = False) -> List[Dict[str, Any]]:
 
 @_control_plane.get("/debug/pool_resource")
 async def debug_pool_resource() -> Dict[str, Any]:
-    pool = get_pool()
-    return {"ok": True, "pool_resource": pool.build_pool_resource_snapshot(proxy_id=_proxy_id, capacity=_proxy_capacity)}
+    return {"ok": True, "pool_resource": _build_pool_resource_snapshot()}
 
 
 @_control_plane.get("/debug/pool_resource_sources")
 async def debug_pool_resource_sources() -> Dict[str, Any]:
-    pool = get_pool()
-    snapshot = pool.build_pool_resource_snapshot(proxy_id=_proxy_id, capacity=_proxy_capacity)
+    snapshot = _build_pool_resource_snapshot()
     return {
         "ok": True,
         "metric_source": snapshot.get("metric_source", {}),

--- a/proxy/resource/p_control_plane.py
+++ b/proxy/resource/p_control_plane.py
@@ -268,6 +268,18 @@ async def debug_pool_resource() -> Dict[str, Any]:
     return {"ok": True, "pool_resource": pool.build_pool_resource_snapshot(proxy_id=_proxy_id, capacity=_proxy_capacity)}
 
 
+@_control_plane.get("/debug/pool_resource_sources")
+async def debug_pool_resource_sources() -> Dict[str, Any]:
+    pool = get_pool()
+    snapshot = pool.build_pool_resource_snapshot(proxy_id=_proxy_id, capacity=_proxy_capacity)
+    return {
+        "ok": True,
+        "metric_source": snapshot.get("metric_source", {}),
+        "metric_quality": snapshot.get("metric_quality", {}),
+        "null_semantics": "0 means measured zero; null means unavailable, not wired, or unknown",
+    }
+
+
 @_control_plane.get("/debug/instance_resources")
 async def debug_instance_resources(include_dead: bool = True) -> Dict[str, Any]:
     pool = get_pool()


### PR DESCRIPTION
### Motivation
- Ensure Scheduler-facing `pool_resource` does not misinterpret unavailable metrics as zero by distinguishing `null` (unavailable) from `0` (measured zero) and provide provenance/quality metadata. 
- Provide coarse queue-depth visibility from the Proxy data plane so the Scheduler can observe queue pressure without exposing per-task payloads. 
- Make the metric contract explicit and discoverable for future scheduling strategies and experiments. 

### Description
- Change `proxy/resource/instance_pool.py` to compute aggregate fields only when underlying instance data exists, return `null` for unavailable aggregates, add `metric_source` and `metric_quality` metadata, add `queue_pressure`, and tighten ratio/quality helpers (`_ratio`, `_quality`).
- Add `snapshot_depths` to `proxy/queue/instance_queues.py` to expose per-instance prepare/ready queue depths and active counts for local diagnostics. 
- Add `queue_depth_snapshot` to `proxy/queue/manager.py` to aggregate per-instance depths into coarse `prepare_queue_depth` and `ready_queue_depth` totals for proxy-level reporting. 
- Wire the queue totals into the proxy `pool_resource` by reading `QueueManager.queue_depth_snapshot()` in `proxy/proxy.py`. 
- Add a proxy control-plane debug endpoint `/debug/pool_resource_sources` in `proxy/resource/p_control_plane.py` that returns `metric_source`, `metric_quality`, and a short null-vs-zero semantic note. 
- Add documentation `doc/pool_resource_metrics.md` describing the field audit, provenance, and null-vs-zero semantics for Scheduler consumers. 

### Testing
- Compiled modified modules with `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile proxy/resource/instance_pool.py proxy/resource/p_control_plane.py proxy/proxy.py proxy/queue/*.py scheduler/resource/control_plane.py scheduler/resource/proxy_pool.py` and the compilation succeeded. 
- Executed a small `InstancePool.build_pool_resource_snapshot` assertion script to validate `null` vs `0` behavior, but the runtime import failed in this environment due to a missing `uvicorn` dependency (the import path pulls `proxy/__init__`), so functional runtime assertions were blocked; static checks and local logic coverage were reviewed instead. 
- Added `doc/pool_resource_metrics.md` and a lightweight proxy debug endpoint to make metric provenance observable during runtime validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56f9c587788320938917455e755d5d)