### PR TITLE
docs: add Codex branch hygiene PR template and workflow (Issue #113)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+- 
+
+## Validation
+
+- [ ] Ran the required validation commands and recorded the results below.
+
+## Diff hygiene
+
+- [ ] Started from the latest `origin/main` before creating this branch.
+- [ ] Created a fresh task branch instead of continuing from a previous Codex branch.
+- [ ] Verified the PR does not include changes from previous unmerged PRs.
+- [ ] Ran `git diff --name-only origin/main...HEAD` and confirmed every changed file belongs to this issue.
+- [ ] Confirmed the diff is limited to the files expected for this issue.
+- [ ] Confirmed no unrelated formatting, cleanup, generated files, or runtime code changes are included.
+
+## Runtime-impact confirmation
+
+- [ ] No runtime code was changed.
+- [ ] Scheduler routing was not changed.
+- [ ] Proxy selection was not changed.
+- [ ] IWS behavior was not changed.
+- [ ] KDN behavior was not changed.
+- [ ] KVCache behavior was not changed.
+- [ ] Instance forwarding was not changed.

--- a/doc/codex_workflow.md
+++ b/doc/codex_workflow.md
@@ -1,0 +1,75 @@
+# Codex Branch Hygiene Workflow
+
+This workflow keeps Codex-generated pull requests small, reviewable, and isolated from previous unmerged work.
+
+## 1. Start from the latest main branch
+
+Before creating a task branch, fetch the current main branch and reset the local base to the remote state:
+
+```bash
+git fetch origin main
+git checkout main
+git reset --hard origin/main
+```
+
+Do not start from an existing Codex branch, a local work branch, or a branch that contains changes from another issue.
+
+## 2. Create a fresh issue branch
+
+Create one new branch per issue from `origin/main`:
+
+```bash
+git checkout -b codex/issue-<number>-<short-topic> origin/main
+```
+
+Use a descriptive branch name that includes the issue number. Do not reuse an old branch name unless the old branch has been deleted and recreated from `origin/main`.
+
+## 3. Keep the diff scoped to the issue
+
+Make only the files required by the issue. Avoid drive-by cleanup, unrelated formatting, generated artifacts, dependency updates, or runtime behavior changes unless the issue explicitly asks for them.
+
+For documentation-only issues, do not modify Scheduler routing, Proxy selection, IWS behavior, KDN behavior, KVCache behavior, Instance forwarding, or other runtime code paths.
+
+## 4. Inspect the diff before committing
+
+Check both the file list and the content diff:
+
+```bash
+git diff --name-only origin/main...HEAD
+git diff origin/main...HEAD
+```
+
+The changed-file list should contain only files that are necessary for the issue. If unrelated files appear, remove those changes before committing.
+
+## 5. Commit only the intended changes
+
+Stage the expected files explicitly:
+
+```bash
+git add <expected-file-1> <expected-file-2>
+git status --short
+git commit -m "docs: document Codex branch hygiene workflow"
+```
+
+Do not use broad staging commands when the working tree contains unrelated changes.
+
+## 6. Prepare the pull request description
+
+The pull request description should make branch hygiene easy to verify. Include:
+
+- base branch and base SHA,
+- head branch and head SHA,
+- changed files,
+- why each changed file is necessary,
+- confirmation that no runtime code was changed,
+- confirmation that Scheduler routing, Proxy selection, IWS, KDN, KVCache, and Instance forwarding were not changed.
+
+## 7. Final validation
+
+Before opening the pull request, run:
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+For a scoped task, the output must match the expected file list from the issue. Any extra file indicates branch contamination or unrelated changes that must be removed before the PR is opened.


### PR DESCRIPTION
### Motivation
- Implement Issue #113 by adding a required PR template and a Codex branch-hygiene document to make Codex-generated pull requests small, reviewable, and verifiable with an explicit Diff hygiene checklist.

### Description
- Added `.github/PULL_REQUEST_TEMPLATE.md` containing a Summary, Validation steps, a required `Diff hygiene` checklist, and a `Runtime-impact confirmation` checklist; and added `doc/codex_workflow.md` documenting the Codex branch hygiene workflow with explicit commands for starting from `origin/main`, creating a fresh issue branch, scoping diffs, inspecting diffs, committing only intended changes, and preparing PR descriptions.

### Testing
- Created branch `codex/issue-113-branch-hygiene` from `origin/main` (base SHA `9e1f1765ec49401ebc74b233d0ee64caf86a5316`) and committed changes (head SHA `e14fbbd3643cfee8d14d612248af438de86779ad`); ran `git diff --name-only origin/main...HEAD` which returned only the expected files `.github/PULL_REQUEST_TEMPLATE.md` and `doc/codex_workflow.md`; `git status` shows the branch ahead by 1 commit; attempted `git fetch origin main` failed due to network 403 but validation used the local `origin/main` ref; no runtime code was changed and Scheduler routing, Proxy selection, IWS, KDN, KVCache, and Instance forwarding were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56fd48e6b083208f11d9beb2c8ba50)