### PR TITLE
feat(proxy): add least-load instance strategy

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -40,6 +40,7 @@ proxy/
 ├── strategy/
 │   ├── base.py                  # Base Instance selection strategy
 │   ├── round_robin.py           # Round-robin Instance selection
+│   ├── least_load.py            # Experimental least-load Instance selection
 │   ├── least_inflight.py        # Reserved for future strategy extension
 │   └── factory.py               # Strategy builder
 ├── queue/
@@ -83,7 +84,7 @@ Common options:
 |---|---|
 | `--host` | Proxy service-plane bind host. The demo also uses it as the advertised host. |
 | `--port` | Proxy service-plane bind port. The demo also uses it as the advertised port. |
-| `--strategy` | Local Instance selection strategy. Currently `round_robin` is the active demo path. |
+| `--strategy` | Local Instance selection strategy. Defaults to `round_robin`; use `least_load` for the experimental load-aware selector. |
 | `--injection-strategy` | Knowledge injection strategy. Use `default` or `iws`. |
 | `--ready-release-policy` | Ready queue release policy: `ordered` or `text_bypass`. |
 | `--kdn-links-json` | Optional static KDN topology metadata. |
@@ -240,11 +241,25 @@ For streaming chat completion, the Proxy forwards the downstream SSE stream and 
 
 ## Instance selection
 
-The active demo strategy is:
+### Proxy Instance selection strategies
 
-| Strategy | Description |
-|---|---|
-| `round_robin` | Selects alive Instances in round-robin order. |
+| Strategy | Aliases | Status | Description |
+|---|---|---|---|
+| `round_robin` | `round_robin`, `round-robin`, `rr` | Default | Selects alive Instances in round-robin order. |
+| `least_load` | `least_load`, `least-load`, `ll` | Experimental | Selects the lowest known Instance load by `load.inflight`, then uses `qps_1m` as a secondary signal. Missing metrics remain unknown rather than zero; if all candidates lack usable load metrics, selection falls back to round-robin. |
+| `kv_aware` | Planned | Planned | Future strategy intended to consider KVCache locality/inventory together with runtime load. |
+
+Select `least_load` from the demo CLI:
+
+```bash
+python3 test/demo_proxy.py --strategy least_load
+```
+
+Or select it through the environment:
+
+```bash
+PROXY_INSTANCE_STRATEGY=least_load python3 test/demo_proxy.py
+```
 
 If no alive Instance is available, the Proxy returns:
 

--- a/proxy/strategy/factory.py
+++ b/proxy/strategy/factory.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from .base import BaseInstanceStrategy
+from .least_load import LeastLoadStrategy
 from .round_robin import RoundRobinStrategy
 
 
@@ -9,4 +10,6 @@ def build_instance_strategy(name: str) -> BaseInstanceStrategy:
     n = (name or "").strip().lower()
     if n in ("rr", "round_robin", "round-robin"):
         return RoundRobinStrategy()
+    if n in ("ll", "least_load", "least-load"):
+        return LeastLoadStrategy()
     raise ValueError(f"unknown instance strategy: {name}")

--- a/proxy/strategy/least_load.py
+++ b/proxy/strategy/least_load.py
@@ -1,0 +1,56 @@
+# proxy/strategy/least_load.py
+"""Implements least-load instance selection for the proxy."""
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from .base import BaseInstanceStrategy, InstanceLike
+from .round_robin import RoundRobinStrategy
+
+
+class LeastLoadStrategy(BaseInstanceStrategy):
+    """
+    Select the Instance with the lowest known load.
+
+    The strategy prefers known ``load.inflight`` values. It uses known
+    ``load.qps_1m`` as a secondary signal, without treating missing metrics as
+    zero. When no useful load metrics are known, it falls back to round-robin.
+    """
+
+    name = "least_load"
+
+    def __init__(self) -> None:
+        self._rr = RoundRobinStrategy()
+
+    def select(self, instances: List[InstanceLike], hint: Optional[Any] = None) -> InstanceLike:
+        if not instances:
+            raise RuntimeError("no instances")
+
+        known_inflight = [it for it in instances if self._inflight(it) is not None]
+        if known_inflight:
+            min_inflight = min(self._inflight(it) for it in known_inflight)
+            inflight_ties = [it for it in known_inflight if self._inflight(it) == min_inflight]
+            return self._select_by_qps_or_rr(inflight_ties)
+
+        return self._select_by_qps_or_rr(instances)
+
+    def _select_by_qps_or_rr(self, instances: List[InstanceLike]) -> InstanceLike:
+        known_qps = [it for it in instances if self._qps_1m(it) is not None]
+        if not known_qps:
+            return self._rr.select(instances)
+
+        min_qps = min(self._qps_1m(it) for it in known_qps)
+        qps_ties = [it for it in known_qps if self._qps_1m(it) == min_qps]
+        return self._rr.select(qps_ties)
+
+    @staticmethod
+    def _inflight(instance: InstanceLike) -> Optional[int]:
+        load = getattr(instance, "load", None)
+        value = getattr(load, "inflight", None)
+        return int(value) if value is not None else None
+
+    @staticmethod
+    def _qps_1m(instance: InstanceLike) -> Optional[float]:
+        load = getattr(instance, "load", None)
+        value = getattr(load, "qps_1m", None)
+        return float(value) if value is not None else None


### PR DESCRIPTION
### Motivation
- Provide an experimental Proxy-side Instance selection strategy that prefers the lowest observed runtime load to enable research into load-aware scheduling while preserving the current demo behavior (`round_robin`).
- Keep changes minimal and scoped to the Proxy strategy surface so experiments can safely enable/disable the policy without affecting Scheduler, KDN, IWS, KVCache, or request forwarding.

### Description
- Added `proxy/strategy/least_load.py` which implements `LeastLoadStrategy(BaseInstanceStrategy)` that: prefers `load.inflight` when known, falls back to `load.qps_1m` as a secondary signal, treats unknown metrics as unknown (not zero), falls back to round-robin when no usable load metrics exist, and uses round-robin to break ties; it raises `RuntimeError("no instances")` for empty input.
- Updated `proxy/strategy/factory.py` to register the following aliases: `round_robin`, `round-robin`, `rr` -> round-robin strategy; and `least_load`, `least-load`, `ll` -> least-load strategy, preserving existing defaults.
- Updated `proxy/README.md` to add a new section "Proxy Instance selection strategies" documenting `round_robin` (default), `least_load` (experimental), aliases, a planned `kv_aware` strategy, and CLI/env examples for selecting the strategy (e.g. `python3 test/demo_proxy.py --strategy least_load` and `PROXY_INSTANCE_STRATEGY=least_load python3 test/demo_proxy.py`).

Changed files and why each is necessary:
- `proxy/strategy/least_load.py` — implements the new selection strategy required by the issue.
- `proxy/strategy/factory.py` — exposes user-facing aliases that resolve to the new strategy without changing default behavior.
- `proxy/README.md` — documents the new strategy and how to enable it from CLI or env for reproducible experiments.

Base/head info:
- Base branch: `main`; Base SHA: `5b3360baa241f9ef7005581eb0ac2eaddf95448e`
- Head branch: `codex/issue-115-least-load-instance-strategy`; Head SHA: `d139b9b17c339606a6188cb9791ba414f1686b10`

Scope confirmation:
- Scheduler routing, Proxy request forwarding, IWS, KDN, KVCache, Resource Agent, `pool_resource` schema, and Instance forwarding were not changed.

### Testing
- Compiled relevant modules: `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile proxy/strategy/base.py proxy/strategy/round_robin.py proxy/strategy/factory.py proxy/strategy/least_load.py proxy/proxy.py test/demo_proxy.py` — compilation passed.
- Factory alias smoke test: used a small import-stub workaround to avoid importing `proxy.proxy` (which requires `uvicorn`) and confirmed the aliases map as expected: `round_robin`, `round-robin`, `rr` -> `round_robin`; `least_load`, `least-load`, `ll` -> `least_load`.
- Behavior smoke tests with fake instances (unit-style): confirmed lower `inflight` wins; all-unknown loads fall back to round-robin; ties round-robin among tied candidates; empty list raises `RuntimeError("no instances")` — all tests passed.
- Environment note: a direct import-based factory smoke test initially failed in this environment because importing `proxy.strategy.factory` executes `proxy/__init__.py` which imports `proxy/proxy.py` and `uvicorn` was not available; package install was blocked by the environment (403), so tests were executed using a safe import stub and local in-process checks instead, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5835540e288320a901436a27d1ae7f)