### PR TITLE
feat(proxy): include per-instance queue pressure in least_load scoring

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -164,7 +164,26 @@ GET  /debug/instance_resources
 GET  /debug/instance_loads
 ```
 
-Use `/debug/instance_loads` to inspect Proxy-maintained per-Instance `inflight` counters, `qps_1m` when present, and queue-depth hints when the queue snapshot provider is available.
+Use `/debug/instance_loads` to inspect Proxy-maintained per-Instance `inflight` counters, `qps_1m` when present, queue-depth hints when the queue snapshot provider is available, and the queue-aware `least_load` score used for Instance selection.
+
+```bash
+curl -sS http://127.0.0.1:8002/debug/instance_loads | python3 -m json.tool
+```
+
+`least_load` uses a conservative deterministic score. `load.inflight` remains the primary signal with implicit weight `1.0`. When queue hints are available, the strategy also adds per-Instance active prepare work, active ready work, prepare queue depth, and ready queue depth. `qps_1m` from Instance heartbeats is supported but disabled by default with weight `0.0`. Missing metrics remain unavailable; they are not converted to measured zeroes, and the strategy falls back to round-robin if no load signal is known. Ties at the minimum score are also broken by round-robin.
+
+Default `least_load` weights are:
+
+| Component | Default weight | Source |
+| --- | ---: | --- |
+| `inflight` | `1.0` | Proxy lifecycle counter |
+| `active_prepare` | `1.0` | Proxy queue manager per-Instance snapshot |
+| `active_ready` | `1.0` | Proxy queue manager per-Instance snapshot |
+| `prepare_queue_depth` | `0.25` | Proxy queue manager per-Instance snapshot |
+| `ready_queue_depth` | `0.25` | Proxy queue manager per-Instance snapshot |
+| `qps_1m` | `0.0` | Instance heartbeat |
+
+The debug response includes `least_load_score.total`, raw `least_load_score.components`, weighted components, metric sources, queue source availability, and the weights used to compute the score.
 
 The reporting path is:
 

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -451,8 +451,17 @@ def select_instance(app: FastAPI, req_obj: SchedulerRequest):
     if not instances:
         return None
 
+    hint = {"request": req_obj}
     try:
-        chosen = strategy.select(instances, hint=req_obj)
+        hint["queue_depths"] = queue_mgr.queue_depth_snapshot()
+    except Exception:
+        logger.warning(
+            "[Proxy] queue snapshot failed during instance select; least_load will use inflight-only metrics",
+            exc_info=True,
+        )
+
+    try:
+        chosen = strategy.select(instances, hint=hint)
         return chosen
     except Exception as e:
         logger.warning("[Proxy] instance select failed: err=%s", str(e))

--- a/proxy/resource/instance_pool.py
+++ b/proxy/resource/instance_pool.py
@@ -7,6 +7,8 @@ import threading
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from proxy.strategy.least_load import LeastLoadStrategy
+
 
 @dataclass
 class InstanceLoad:
@@ -183,6 +185,9 @@ class InstancePool:
         with self._lock:
             items = list(self._items.values())
 
+        score_strategy = LeastLoadStrategy()
+        score_hint = {"queue_depths": queue_depths} if queue_depths is not None else None
+
         instances: List[Dict[str, Any]] = []
         for it in items:
             is_alive = (now - int(it.last_seen_at)) <= self._ttl_s
@@ -191,6 +196,7 @@ class InstancePool:
             queue_item = per_instance_queue.get(it.instance_id, {})
             inflight = it.load.inflight
             qps_1m = it.load.qps_1m
+            least_load_score = score_strategy.compute_score(it, hint=score_hint)
             instances.append({
                 "instance_id": it.instance_id,
                 "is_alive": is_alive,
@@ -200,14 +206,7 @@ class InstancePool:
                 "ready_queue_depth": queue_item.get("ready_queue_depth"),
                 "active_prepare": queue_item.get("active_prepare"),
                 "active_ready": queue_item.get("active_ready"),
-                "least_load_score": {
-                    "primary": "inflight" if inflight is not None else None,
-                    "primary_value": inflight,
-                    "primary_source": "proxy_lifecycle_counter" if inflight is not None else "unavailable",
-                    "secondary": "qps_1m" if qps_1m is not None else None,
-                    "secondary_value": qps_1m,
-                    "secondary_source": "instance_heartbeat" if qps_1m is not None else "unavailable",
-                },
+                "least_load_score": least_load_score,
             })
 
         return {

--- a/proxy/strategy/least_load.py
+++ b/proxy/strategy/least_load.py
@@ -2,46 +2,133 @@
 """Implements least-load instance selection for the proxy."""
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 from .base import BaseInstanceStrategy, InstanceLike
 from .round_robin import RoundRobinStrategy
 
 
+@dataclass(frozen=True)
+class LeastLoadWeights:
+    """Conservative queue-aware weights for least-load scoring."""
+
+    active_prepare: float = 1.0
+    active_ready: float = 1.0
+    prepare_queue_depth: float = 0.25
+    ready_queue_depth: float = 0.25
+    qps_1m: float = 0.0
+
+
 class LeastLoadStrategy(BaseInstanceStrategy):
     """
-    Select the Instance with the lowest known load.
+    Select the Instance with the lowest known weighted load.
 
-    The strategy prefers known ``load.inflight`` values. It uses known
-    ``load.qps_1m`` as a secondary signal, without treating missing metrics as
-    zero. When no useful load metrics are known, it falls back to round-robin.
+    ``load.inflight`` remains the primary signal with implicit weight 1.0.
+    Queue hints are added when the Proxy queue manager provides per-Instance
+    measurements. Missing metrics stay unknown rather than becoming measured
+    zeros. If no candidate has any measurable score component, selection falls
+    back to round-robin.
     """
 
     name = "least_load"
 
-    def __init__(self) -> None:
+    def __init__(self, weights: Optional[LeastLoadWeights] = None) -> None:
         self._rr = RoundRobinStrategy()
+        self.weights = weights or LeastLoadWeights()
 
     def select(self, instances: List[InstanceLike], hint: Optional[Any] = None) -> InstanceLike:
         if not instances:
             raise RuntimeError("no instances")
 
-        known_inflight = [it for it in instances if self._inflight(it) is not None]
-        if known_inflight:
-            min_inflight = min(self._inflight(it) for it in known_inflight)
-            inflight_ties = [it for it in known_inflight if self._inflight(it) == min_inflight]
-            return self._select_by_qps_or_rr(inflight_ties)
-
-        return self._select_by_qps_or_rr(instances)
-
-    def _select_by_qps_or_rr(self, instances: List[InstanceLike]) -> InstanceLike:
-        known_qps = [it for it in instances if self._qps_1m(it) is not None]
-        if not known_qps:
+        scored = [(it, self.compute_score(it, hint)) for it in instances]
+        known_scores = [(it, score) for it, score in scored if score["total"] is not None]
+        if not known_scores:
             return self._rr.select(instances)
 
-        min_qps = min(self._qps_1m(it) for it in known_qps)
-        qps_ties = [it for it in known_qps if self._qps_1m(it) == min_qps]
-        return self._rr.select(qps_ties)
+        min_score = min(score["total"] for _, score in known_scores)
+        ties = [it for it, score in known_scores if score["total"] == min_score]
+        return self._rr.select(ties)
+
+    def compute_score(self, instance: InstanceLike, hint: Optional[Any] = None) -> Dict[str, Any]:
+        """Compute weighted score details for one Instance without mutating state."""
+        components: Dict[str, Optional[float]] = {}
+        sources: Dict[str, str] = {}
+
+        inflight = self._inflight(instance)
+        if inflight is not None:
+            components["inflight"] = float(inflight)
+            sources["inflight"] = "proxy_lifecycle_counter"
+
+        queue_item = self._queue_info(instance, hint)
+        queue_source = "proxy_queue_manager" if queue_item is not None else "unavailable"
+        if queue_item is not None:
+            for key in ("active_prepare", "active_ready", "prepare_queue_depth", "ready_queue_depth"):
+                value = self._number_from_mapping(queue_item, key)
+                if value is not None:
+                    components[key] = value
+                    sources[key] = "proxy_queue_manager"
+
+        qps_1m = self._qps_1m(instance)
+        if qps_1m is not None:
+            components["qps_1m"] = qps_1m
+            sources["qps_1m"] = "instance_heartbeat"
+
+        weighted_components = self._weighted_components(components)
+        total = sum(weighted_components.values()) if weighted_components else None
+        return {
+            "total": total,
+            "components": components,
+            "weighted_components": weighted_components,
+            "source": sources,
+            "queue_source": queue_source,
+            "weights": self.weights_dict(),
+        }
+
+    def weights_dict(self) -> Dict[str, float]:
+        return {
+            "inflight": 1.0,
+            "active_prepare": self.weights.active_prepare,
+            "active_ready": self.weights.active_ready,
+            "prepare_queue_depth": self.weights.prepare_queue_depth,
+            "ready_queue_depth": self.weights.ready_queue_depth,
+            "qps_1m": self.weights.qps_1m,
+        }
+
+    def _weighted_components(self, components: Dict[str, Optional[float]]) -> Dict[str, float]:
+        weights = self.weights_dict()
+        weighted: Dict[str, float] = {}
+        for key, value in components.items():
+            if value is None:
+                continue
+            weight = weights.get(key)
+            if weight is None or weight == 0.0:
+                continue
+            weighted[key] = float(value) * float(weight)
+        return weighted
+
+    @staticmethod
+    def _queue_info(instance: InstanceLike, hint: Optional[Any]) -> Optional[Dict[str, Any]]:
+        if not isinstance(hint, dict):
+            return None
+        queue_depths = hint.get("queue_depths")
+        if not isinstance(queue_depths, dict):
+            return None
+        per_instance = queue_depths.get("per_instance")
+        if not isinstance(per_instance, dict):
+            return None
+        queue_item = per_instance.get(getattr(instance, "instance_id", None))
+        return queue_item if isinstance(queue_item, dict) else None
+
+    @staticmethod
+    def _number_from_mapping(mapping: Dict[str, Any], key: str) -> Optional[float]:
+        value = mapping.get(key)
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
     @staticmethod
     def _inflight(instance: InstanceLike) -> Optional[int]:


### PR DESCRIPTION
### Motivation
- Reduce instance queue pressure by making `least_load` consider per-Instance queue hints in addition to the Proxy-maintained `inflight` lifecycle counter. 
- Preserve existing safe defaults and fallbacks so selection remains compatible when queue snapshots or metrics are missing. 
- Improve observability by exposing the exact `least_load` score components in the Proxy debug endpoint for reproducible experiments.

### Description
- Base/head info: base branch `main` at SHA `7b3489df4327032eaa884241e001cc4e87d8d0f6`, head branch `codex/issue-119-least-load-queue-pressure` at SHA `118fa5c095047dce103797563bf917f148a1f4b3`.
- Changed files and why: `proxy/strategy/least_load.py` adds deterministic weighted scoring and helpers (`compute_score`, queue-info extraction, safe numeric parsing, weights struct) so selection can combine `inflight` with per-instance `active_prepare`, `active_ready`, `prepare_queue_depth`, `ready_queue_depth`, and optional `qps_1m`; `proxy/proxy.py` updates `select_instance(...)` to build the hint shape `{ "request": req_obj, "queue_depths": queue_mgr.queue_depth_snapshot() }` and to continue with inflight-only behavior if the queue snapshot call fails; `proxy/resource/instance_pool.py` reuses `LeastLoadStrategy.compute_score(...)` to populate `least_load_score` in `/debug/instance_loads` so debug output matches runtime scoring; `proxy/README.md` documents the new behavior, default weights, curl debug example, and tie/fallback semantics.
- Scoring summary: the score is the weighted sum `inflight + active_prepare_weight*active_prepare + active_ready_weight*active_ready + prepare_depth_weight*prepare_queue_depth + ready_depth_weight*ready_queue_depth + qps_weight*qps_1m` with conservative defaults `inflight: 1.0 (implicit)`, `active_prepare: 1.0`, `active_ready: 1.0`, `prepare_queue_depth: 0.25`, `ready_queue_depth: 0.25`, and `qps_1m: 0.0` (disabled by default). 
- Selection semantics: missing or invalid metrics are treated as unavailable (not zero), ties are broken by round-robin, and if no candidate has any measurable score component selection falls back to round-robin; `round_robin` strategy is unchanged and continues to ignore hints.
- Non-goal confirmation: no changes were made to Scheduler routing, KDN / KVCache logic, IWS decision logic, queue scheduling/release behavior, Resource Agent sampling, or request forwarding semantics.

### Testing
- Compiled the modified modules with `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile proxy/strategy/least_load.py proxy/strategy/factory.py proxy/proxy.py proxy/resource/instance_pool.py proxy/resource/p_control_plane.py proxy/queue/*.py test/demo_proxy.py` and it succeeded. 
- Executed unit-style smoke assertions (inline Python assertions) that validated lower `inflight` wins, higher queue pressure loses when `inflight` is equal, `active_prepare`/`active_ready` and `prepare_queue_depth`/`ready_queue_depth` affect the score according to the weights, missing queue hints fallback to inflight-only behavior, all-unknown load falls back to round-robin, and ties are broken round-robin, and these assertions passed. 
- Note: `git fetch origin main` could not be executed in this workspace because `origin` is not configured, so the PR records the local base SHA above; no runtime integration server tests were executed in this environment (see README for runtime smoke instructions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d744cf7b4832094428f66050ca966)