### PR TITLE
Fix CLI and UI curl command parsing

### DIFF
--- a/UI/client_ui/app.py
+++ b/UI/client_ui/app.py
@@ -1,14 +1,14 @@
 """Serve the CacheRoute web client UI and bridge UI actions to client.py.
 
 This FastAPI app renders the client page, parses curl-like input through the
-existing CLI parser, validates OpenAI-style payloads, and sends requests to the
-Scheduler. It can run standalone or be mounted by another CacheRoute service.
+shared command parser, validates OpenAI-style payloads, and sends requests to
+the Scheduler. It can run standalone or be mounted by another CacheRoute service.
 """
 from __future__ import annotations
 
 import json
 from dataclasses import asdict
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 from pathlib import Path
 
 from fastapi import APIRouter, FastAPI, Request
@@ -16,8 +16,9 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-# Reuse the existing low-level capabilities from client.py.
+# Reuse the existing low-level request and response capabilities from client.py.
 from client import client as client_core
+from client.command_input import parse_curl_like_command
 
 BASE_DIR = Path(__file__).resolve().parent          # .../UI/client_ui
 TEMPLATES_DIR = BASE_DIR / "templates"
@@ -60,17 +61,17 @@ def create_client_ui_app(
     @router.post("/ui/api/parse_curl")
     async def parse_curl(payload: Dict[str, Any]):
         """
-        Input: { "line": "<curl-like line>" }
+        Input: { "line": "<single-line or multiline curl-like command>" }
         Output: { url, headers, body } or error.
         """
-        line = (payload.get("line") or "").strip()
+        line = str(payload.get("line") or "").strip()
         if not line:
-            return JSONResponse(status_code=400, content={"error": "line is empty"})
+            return JSONResponse(status_code=400, content={"error": "command is empty"})
         try:
-            parsed = client_core.parse_cli_line(line)
+            parsed = parse_curl_like_command(line)
             return {"parsed": asdict(parsed)}
-        except Exception as e:
-            return JSONResponse(status_code=400, content={"error": str(e)})
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"error": str(exc)})
 
     @router.post("/ui/api/validate")
     async def validate_req(payload: Dict[str, Any]):
@@ -86,8 +87,8 @@ def create_client_ui_app(
             )
             errors = client_core.validate_openai_like_request(parsed)
             return {"ok": len(errors) == 0, "errors": errors}
-        except Exception as e:
-            return JSONResponse(status_code=400, content={"ok": False, "errors": [str(e)]})
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"ok": False, "errors": [str(exc)]})
 
     @router.post("/ui/api/send")
     async def send_req(payload: Dict[str, Any]):
@@ -101,7 +102,7 @@ def create_client_ui_app(
         body = dict(payload.get("body") or {})
 
         # Fill Content-Type in the same way as client.py.
-        if not any(k.lower() == "content-type" for k in headers):
+        if not any(key.lower() == "content-type" for key in headers):
             headers["Content-Type"] = "application/json"
 
         parsed = client_core.ParsedRequest(url=url, headers=headers, body=body)
@@ -112,22 +113,21 @@ def create_client_ui_app(
             return JSONResponse(status_code=400, content={"error": "validation_failed", "errors": errors})
 
         try:
-            resp = client_core.send_request(parsed, timeout=timeout)
-        except Exception as e:
-            return JSONResponse(status_code=500, content={"error": str(e)})
+            response = client_core.send_request(parsed, timeout=timeout)
+        except Exception as exc:
+            return JSONResponse(status_code=500, content={"error": str(exc)})
 
-        out: Dict[str, Any] = {
-            "status_code": resp.status_code,
-            "headers": dict(resp.headers),
-            "body_text": resp.text,
+        output: Dict[str, Any] = {
+            "status_code": response.status_code,
+            "headers": dict(response.headers),
+            "body_text": response.text,
         }
-        # Try to parse the response as JSON.
         try:
-            out["body_json"] = resp.json()
+            output["body_json"] = response.json()
         except Exception:
-            out["body_json"] = None
+            output["body_json"] = None
 
-        return out
+        return output
 
     app.include_router(router)
     return app
@@ -138,9 +138,7 @@ def run_client_ui(
     port: int,
     default_scheduler_url: str,
 ) -> None:
-    """
-    Standalone entry point: python -m UI.client_ui.app.
-    """
+    """Standalone entry point: python -m UI.client_ui.app."""
     import uvicorn
 
     app = create_client_ui_app(default_scheduler_url=default_scheduler_url)

--- a/UI/client_ui/static/app.js
+++ b/UI/client_ui/static/app.js
@@ -77,7 +77,7 @@ loadExample();
 
 $("btn-parse-curl").addEventListener("click", async () => {
   const line = $("curlLine").value.trim();
-  if (!line) { $("curlParseMsg").textContent = "Please enter one command line"; return; }
+  if (!line) { $("curlParseMsg").textContent = "Please enter a curl-like command"; return; }
 
   const res = await apiPost("/ui/api/parse_curl", { line });
   if (!res.ok) {

--- a/UI/client_ui/templates/index.html
+++ b/UI/client_ui/templates/index.html
@@ -83,9 +83,7 @@
           </div>
           <div class="card-bd space-y-3">
             <textarea id="curlLine" class="textarea font-mono" rows="9"
-              placeholder='curl http://127.0.0.1:7001/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '\''{"model":"llama3-70b","messages":[{"role":"user","content":"What is vLLM?"}]}'\''></textarea>
+              placeholder="Paste a URL-first command or a standard single-line/multiline curl command"></textarea>
             <button id="btn-parse-curl" class="btn btn-ghost">Parse</button>
             <div id="curlParseMsg" class="text-sm text-slate-400"></div>
           </div>

--- a/UI/client_ui/templates/index.html
+++ b/UI/client_ui/templates/index.html
@@ -78,12 +78,14 @@
 
         <div class="card mt-6">
           <div class="card-hd">
-            <div class="font-medium">Curl-like One-line Command</div>
-            <div class="text-xs text-slate-400">Paste a command and parse it into the form by reusing client.parse_cli_line.</div>
+            <div class="font-medium">Curl-like Command</div>
+            <div class="text-xs text-slate-400">Accepts URL-first input or standard curl, in one line or multiple lines.</div>
           </div>
           <div class="card-bd space-y-3">
-            <textarea id="curlLine" class="textarea font-mono" rows="4"
-              placeholder='http://127.0.0.1:7001/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"...\",\"messages\":[...]}"'></textarea>
+            <textarea id="curlLine" class="textarea font-mono" rows="9"
+              placeholder='curl http://127.0.0.1:7001/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '\''{"model":"llama3-70b","messages":[{"role":"user","content":"What is vLLM?"}]}'\''></textarea>
             <button id="btn-parse-curl" class="btn btn-ghost">Parse</button>
             <div id="curlParseMsg" class="text-sm text-slate-400"></div>
           </div>
@@ -120,6 +122,7 @@
           <div class="card-bd text-sm text-slate-300 space-y-2">
             <div>• The UI does not bypass validation: it calls validate_openai_like_request again before sending.</div>
             <div>• To extend allowed fields, update ALLOWED_OPTION_FIELDS in core.config.</div>
+            <div>• Use ASCII single or double quotes when pasting shell commands.</div>
           </div>
         </div>
       </div>

--- a/client/command_input.py
+++ b/client/command_input.py
@@ -10,14 +10,9 @@ from urllib.parse import urlparse
 
 
 _LINE_CONTINUATION_RE = re.compile(r"\\[ \t]*\r?\n")
-_SMART_QUOTES = {
-    "\u2018": "'",
-    "\u2019": "'",
-    "\u201c": '"',
-    "\u201d": '"',
-    "\uff02": '"',
-    "\uff07": "'",
-}
+_SMART_SHELL_QUOTE_RE = re.compile(
+    r"(?:^|\s)(?:-H|--header|-d|--data|--data-raw)\s*([\u2018\u2019\u201c\u201d\uff02\uff07])"
+)
 
 
 @dataclass
@@ -59,14 +54,13 @@ def command_needs_continuation(text: str) -> bool:
     return False
 
 
-def _raise_for_smart_quotes(text: str) -> None:
-    found = sorted({ch for ch in text if ch in _SMART_QUOTES})
-    if not found:
+def _raise_for_smart_shell_quotes(text: str) -> None:
+    match = _SMART_SHELL_QUOTE_RE.search(text)
+    if match is None:
         return
-    rendered = " ".join(repr(ch) for ch in found)
     raise ValueError(
-        "typographic/full-width quote detected "
-        f"({rendered}); replace it with ASCII single or double quotes"
+        "typographic/full-width quote used as a shell argument delimiter; "
+        "replace the outer quote after -H/-d with an ASCII single or double quote"
     )
 
 
@@ -87,13 +81,13 @@ def parse_curl_like_command(text: str) -> ParsedRequest:
     if not normalized:
         raise ValueError("input is empty")
 
-    _raise_for_smart_quotes(normalized)
+    _raise_for_smart_shell_quotes(normalized)
 
     try:
         tokens = shlex.split(normalized, posix=True)
     except ValueError as exc:
         raise ValueError(
-            f"failed to parse command line: {exc}; check that all quotes are ASCII and closed"
+            f"failed to parse command line: {exc}; check that all shell quotes are ASCII and closed"
         ) from exc
 
     if not tokens:

--- a/client/command_input.py
+++ b/client/command_input.py
@@ -1,0 +1,186 @@
+"""Parse curl-like CacheRoute client input consistently for CLI and browser UI."""
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+
+_LINE_CONTINUATION_RE = re.compile(r"\\[ \t]*\r?\n")
+_SMART_QUOTES = {
+    "\u2018": "'",
+    "\u2019": "'",
+    "\u201c": '"',
+    "\u201d": '"',
+    "\uff02": '"',
+    "\uff07": "'",
+}
+
+
+@dataclass
+class ParsedRequest:
+    """Represent one parsed HTTP request."""
+
+    url: str
+    headers: Dict[str, str]
+    body: Dict[str, Any]
+
+
+def normalize_command_text(text: str) -> str:
+    """Normalize pasted shell text without changing JSON payload content."""
+    if not isinstance(text, str):
+        raise ValueError("command input must be a string")
+
+    # Browser/Windows paste may contain CRLF and non-breaking spaces.
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n").replace("\u00a0", " ")
+
+    # A shell backslash followed by a newline is a line continuation, not an
+    # argument. Python shlex otherwise emits the newline as a separate token.
+    normalized = _LINE_CONTINUATION_RE.sub(" ", normalized)
+    return normalized.strip()
+
+
+def command_needs_continuation(text: str) -> bool:
+    """Return True when an interactive command is visibly incomplete."""
+    raw = text.rstrip()
+    if not raw:
+        return False
+    if raw.endswith("\\"):
+        return True
+
+    try:
+        shlex.split(normalize_command_text(text), posix=True)
+    except ValueError as exc:
+        message = str(exc).lower()
+        return "no closing quotation" in message or "no escaped character" in message
+    return False
+
+
+def _raise_for_smart_quotes(text: str) -> None:
+    found = sorted({ch for ch in text if ch in _SMART_QUOTES})
+    if not found:
+        return
+    rendered = " ".join(repr(ch) for ch in found)
+    raise ValueError(
+        "typographic/full-width quote detected "
+        f"({rendered}); replace it with ASCII single or double quotes"
+    )
+
+
+def parse_curl_like_command(text: str) -> ParsedRequest:
+    """Parse a URL-first or standard ``curl`` command.
+
+    Accepted examples::
+
+        http://127.0.0.1:7001/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"llama3-70b","messages":[]}'
+
+        curl http://127.0.0.1:7001/v1/chat/completions \\
+          -H "Content-Type: application/json" \\
+          -d '{"model":"llama3-70b","messages":[]}'
+
+    Only POST requests are supported. ``curl`` and ``-X POST`` are optional.
+    """
+    normalized = normalize_command_text(text)
+    if not normalized:
+        raise ValueError("input is empty")
+
+    _raise_for_smart_quotes(normalized)
+
+    try:
+        tokens = shlex.split(normalized, posix=True)
+    except ValueError as exc:
+        raise ValueError(
+            f"failed to parse command line: {exc}; check that all quotes are ASCII and closed"
+        ) from exc
+
+    if not tokens:
+        raise ValueError("no arguments were parsed; check the input")
+
+    if tokens[0].lower() == "curl":
+        tokens = tokens[1:]
+    if not tokens:
+        raise ValueError("curl command is missing a URL")
+
+    url: Optional[str] = None
+    headers: Dict[str, str] = {}
+    body_str: Optional[str] = None
+
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+
+        if token in ("-H", "--header"):
+            if i + 1 >= len(tokens):
+                raise ValueError(
+                    'missing value after -H/--header, for example: -H "Content-Type: application/json"'
+                )
+            header_str = tokens[i + 1]
+            if ":" not in header_str:
+                raise ValueError(
+                    f'invalid header format: {header_str}; expected "Key: Value"'
+                )
+            key, value = header_str.split(":", 1)
+            headers[key.strip()] = value.strip()
+            i += 2
+            continue
+
+        if token in ("-d", "--data", "--data-raw"):
+            if i + 1 >= len(tokens):
+                raise ValueError("missing JSON string after -d/--data/--data-raw")
+            body_str = tokens[i + 1]
+            i += 2
+            continue
+
+        if token in ("-X", "--request"):
+            if i + 1 >= len(tokens):
+                raise ValueError("missing HTTP method after -X/--request")
+            method = tokens[i + 1].upper()
+            if method != "POST":
+                raise ValueError(f"only POST is supported; received method: {method}")
+            i += 2
+            continue
+
+        if token == "--url":
+            if i + 1 >= len(tokens):
+                raise ValueError("missing URL after --url")
+            if url is not None:
+                raise ValueError("multiple URLs were provided")
+            url = tokens[i + 1]
+            i += 2
+            continue
+
+        parsed_token = urlparse(token)
+        if parsed_token.scheme in ("http", "https") and parsed_token.netloc:
+            if url is not None:
+                raise ValueError("multiple URLs were provided")
+            url = token
+            i += 1
+            continue
+
+        raise ValueError(f"unrecognized argument: {token}")
+
+    if url is None:
+        raise ValueError("a complete HTTP/HTTPS URL is required")
+
+    parsed_url = urlparse(url)
+    if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
+        raise ValueError(f"invalid HTTP/HTTPS URL: {url}")
+
+    if body_str is None:
+        raise ValueError("request body is missing; pass JSON with -d/--data/--data-raw")
+
+    try:
+        body = json.loads(body_str)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"failed to parse request-body JSON: {exc}") from exc
+
+    if not isinstance(body, dict):
+        raise ValueError("request-body JSON must be an object")
+
+    if not any(key.lower() == "content-type" for key in headers):
+        headers["Content-Type"] = "application/json"
+
+    return ParsedRequest(url=url, headers=headers, body=body)

--- a/client/repl.py
+++ b/client/repl.py
@@ -1,0 +1,129 @@
+"""Interactive CacheRoute client REPL with multiline curl support."""
+from __future__ import annotations
+
+from typing import Optional
+
+import requests
+
+from client import client as client_core
+from client.command_input import command_needs_continuation, parse_curl_like_command
+
+
+def print_help() -> None:
+    print(
+        r'''
+Usage examples:
+
+  URL-first one-line form:
+    http://127.0.0.1:7001/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"llama3-70b","messages":[{"role":"user","content":"What is vLLM?"}],"max_tokens":64,"stream":true,"RAG":true,"Injection_type":"kvcache"}'
+
+  Standard multiline curl form:
+    curl http://127.0.0.1:7001/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "llama3-70b",
+        "messages": [{"role": "user", "content": "What is vLLM?"}],
+        "max_tokens": 64,
+        "stream": true,
+        "RAG": true,
+        "Injection_type": "kvcache"
+      }'
+
+Commands:
+  :help      Show this help message
+  :quit      Exit
+  :exit      Exit
+  :cancel    Cancel the current multiline command
+'''
+    )
+
+
+def _read_command() -> Optional[str]:
+    """Read one complete command, continuing after ``\\`` or open quotes."""
+    parts: list[str] = []
+    prompt = "client> "
+
+    while True:
+        try:
+            line = input(prompt)
+        except EOFError:
+            if not parts:
+                return None
+            print("\n[ERROR] Incomplete command discarded.")
+            return ""
+        except KeyboardInterrupt:
+            if parts:
+                print("\nMultiline command cancelled.")
+                return ""
+            print()
+            return None
+
+        if not parts and line.strip().lower() in {":quit", "quit", ":exit", "exit"}:
+            return line.strip()
+
+        if parts and line.strip().lower() in {":cancel", "cancel"}:
+            print("Multiline command cancelled.")
+            return ""
+
+        parts.append(line)
+        command = "\n".join(parts)
+        if command_needs_continuation(command):
+            prompt = "...> "
+            continue
+        return command
+
+
+def run_repl() -> None:
+    """Run the interactive CLI using the shared robust command parser."""
+    print("=== CacheRoute Client REPL ===")
+    print("Enter a URL-first or curl command; multiline input is supported.")
+    print("Use :help for examples or :quit to exit.")
+
+    while True:
+        command = _read_command()
+        if command is None:
+            print("Exiting.")
+            break
+        if not command.strip():
+            continue
+
+        normalized_command = command.strip()
+        command_name = normalized_command[1:] if normalized_command.startswith(":") else normalized_command
+        command_name = command_name.lower()
+
+        if command_name in {"quit", "exit"}:
+            print("Exiting.")
+            break
+        if command_name in {"help", "h", "?"}:
+            print_help()
+            continue
+        if command_name == "cancel":
+            continue
+
+        try:
+            parsed = parse_curl_like_command(command)
+        except ValueError as exc:
+            client_core.logger.error("request parsing failed: %s", exc)
+            print(f"[ERROR] {exc}")
+            continue
+
+        errors = client_core.validate_openai_like_request(parsed)
+        if errors:
+            client_core.logger.error("request validation failed: %s", "; ".join(errors))
+            print("[ERROR] Request field validation failed:")
+            for message in errors:
+                print("  -", message)
+            continue
+
+        try:
+            response = client_core.send_request(parsed)
+        except requests.RequestException as exc:
+            client_core.logger.error("HTTP request failed: %s", exc)
+            print(f"[ERROR] HTTP request failed: {exc}")
+            continue
+
+        client_core.pretty_print_response(response, parsed.body)
+
+
+if __name__ == "__main__":
+    run_repl()

--- a/test/demo_client.py
+++ b/test/demo_client.py
@@ -28,21 +28,16 @@ def _ensure_project_root_on_syspath() -> None:
 
 
 def run_cli() -> None:
-    """
-    CLI mode: directly reuse main() from client.py.
-    """
+    """Start the multiline-aware CacheRoute client REPL."""
     _ensure_project_root_on_syspath()
 
-    # If your client module is client/client.py, this import is recommended
-    # - If client/__init__.py already does from .client import *, direct import client also works
-    try:
-        from client.client import run_repl as client_entry  # client/ directory + client.py
-    except Exception:
-        # Fallback: if client.py is placed at the repository root as a non-package module
-        from client import run_repl as client_entry  # type: ignore
+    from client.repl import run_repl
 
-    print("[demo_client] entering REPL... (if you do not see a prompt, press Enter once)", flush=True)
-    client_entry()
+    print(
+        "[demo_client] entering REPL... (if you do not see a prompt, press Enter once)",
+        flush=True,
+    )
+    run_repl()
 
 
 def run_ui(host: str, port: int, scheduler_url: str) -> None:

--- a/test/test_client_command_input.py
+++ b/test/test_client_command_input.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import unittest
+
+from client.command_input import parse_curl_like_command
+
+
+class ClientCommandInputTest(unittest.TestCase):
+    def test_url_first_single_line_command(self) -> None:
+        command = (
+            'http://127.0.0.1:7001/v1/chat/completions '
+            '-H "Content-Type: application/json" '
+            "-d '{\"model\":\"llama3-70b\",\"messages\":[{\"role\":\"user\","
+            "\"content\":\"What is vLLM?\"}],\"max_tokens\":64,\"stream\":true,"
+            "\"RAG\":true,\"Injection_type\":\"kvcache\"}'"
+        )
+
+        parsed = parse_curl_like_command(command)
+
+        self.assertEqual(parsed.url, "http://127.0.0.1:7001/v1/chat/completions")
+        self.assertEqual(parsed.headers["Content-Type"], "application/json")
+        self.assertEqual(parsed.body["model"], "llama3-70b")
+        self.assertTrue(parsed.body["stream"])
+        self.assertEqual(parsed.body["Injection_type"], "kvcache")
+
+    def test_standard_multiline_curl_command(self) -> None:
+        command = r'''curl http://127.0.0.1:7001/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama3-70b",
+    "messages": [{"role": "user", "content": "What is vLLM?"}],
+    "max_tokens": 64,
+    "stream": false,
+    "RAG": true
+  }' '''
+
+        parsed = parse_curl_like_command(command)
+
+        self.assertEqual(parsed.body["messages"][0]["content"], "What is vLLM?")
+        self.assertFalse(parsed.body["stream"])
+
+    def test_curl_request_and_url_options(self) -> None:
+        command = (
+            "curl -X POST --url http://127.0.0.1:7001/v1/completions "
+            "--data-raw '{\"model\":\"llama3-70b\",\"prompt\":\"hello\"}'"
+        )
+
+        parsed = parse_curl_like_command(command)
+
+        self.assertEqual(parsed.url, "http://127.0.0.1:7001/v1/completions")
+        self.assertEqual(parsed.body["prompt"], "hello")
+        self.assertEqual(parsed.headers["Content-Type"], "application/json")
+
+    def test_typographic_quotes_get_actionable_error(self) -> None:
+        command = (
+            "http://127.0.0.1:7001/v1/chat/completions "
+            "-d ‘{\"model\":\"llama3-70b\",\"messages\":[]}’"
+        )
+
+        with self.assertRaisesRegex(ValueError, "typographic/full-width quote"):
+            parse_curl_like_command(command)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Added a shared curl-like command parser for both CLI and browser UI.
- Kept the existing URL-first one-line format valid.
- Added support for an optional `curl` prefix, `-X POST`, `--url`, and shell backslash continuations.
- Added a multiline-aware REPL that continues with `...>` after a trailing backslash or an open quote.
- Updated the browser UI parser to accept single-line and multiline commands.
- Added clearer errors for full-width or typographic quotes used as shell argument delimiters.
- Added regression tests for the exact URL-first command, multiline curl, and curl option forms.

## Why

The previous REPL called `input()` once per line and passed each line directly to `shlex.split()`. Pasting a README-style multiline curl therefore produced `No escaped character` and then treated every subsequent JSON line as a new request. The browser UI reused the same one-line parser. The exact URL-first single-line command is valid and remains supported.

## Validation

- Verified the exact reported URL-first command with the new parser.
- Verified a standard multiline curl command containing backslash continuations and formatted JSON.
- Verified `curl -X POST --url ... --data-raw ...`.
- Added `unittest` regression coverage in `test/test_client_command_input.py`.
- A live Scheduler/Proxy/Instance request was not sent from this environment.