### PR TITLE
feat(demo_instance): auto-start resource dashboard UI

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -127,6 +127,12 @@ INSTANCE_RESOURCE_REPORT_HZ = 1.0                               # Resource repor
 INSTANCE_RESOURCE_REPORT_INTERVAL_MS = 1000                     # Resource report interval in milliseconds.
 INSTANCE_RESOURCE_REPORT_TIMEOUT_S = 2.0                        # Timeout for sending one resource report.
 
+# Instance browser resource dashboard, disabled by default for backward-compatible demo startup.
+INSTANCE_UI_ENABLE = False                                      # Enable demo_instance.py integrated browser dashboard.
+INSTANCE_UI_LISTEN = "0.0.0.0:9202"                            # Listen address for the integrated Instance resource dashboard.
+INSTANCE_UI_OPEN_BROWSER = False                                # Open a local browser for config/env-enabled UI. Explicit --ui defaults to opening.
+INSTANCE_UI_START_TIMEOUT_S = 5.0                               # Maximum wait time for dashboard readiness.
+
 # ====================================================================#
 #                               Other                                 #
 # ====================================================================#

--- a/instance/instance_api.py
+++ b/instance/instance_api.py
@@ -221,12 +221,17 @@ async def lifespan(app: FastAPI):
     app.state._hb_task = task # type: ignore
 
     resource_monitor = getattr(app.state, "_demo_resource_monitor", None)  # type: ignore
+    dashboard = getattr(app.state, "_demo_dashboard", None)  # type: ignore
     registration_ok = runtime_instance_id == getattr(reg, "instance_id", None) if "reg" in locals() else False
     if resource_monitor is not None:
         if registration_ok:
             await resource_monitor.start_after_registration(runtime_instance_id=runtime_instance_id, stop_event=stop, logger=logger)
         else:
             resource_monitor.skip_after_registration_failure(logger=logger)
+            if dashboard is not None and getattr(dashboard, "enabled", False):
+                await resource_monitor.ensure_agent_for_ui(runtime_instance_id=runtime_instance_id, logger=logger)
+    if dashboard is not None:
+        await dashboard.start(runtime_instance_id=runtime_instance_id, logger=logger)
 
     app.state._topology_task = asyncio.create_task(  # type: ignore
         _run_topology_discovery(client=client, instance_id=runtime_instance_id, logger=logger)
@@ -244,6 +249,12 @@ async def lifespan(app: FastAPI):
             topo_task = getattr(app.state, "_topology_task", None)  # type: ignore
             if topo_task is not None:
                 topo_task.cancel()
+        except Exception:
+            pass
+        try:
+            dashboard = getattr(app.state, "_demo_dashboard", None)  # type: ignore
+            if dashboard is not None:
+                await dashboard.stop(logger=logger)
         except Exception:
             pass
         try:

--- a/instance/resource_dashboard/README.md
+++ b/instance/resource_dashboard/README.md
@@ -245,3 +245,41 @@ POST /api/agent/stop
 - Add richer per-Instance queue and KVCache metrics once they are exported by Instance.
 - Replace `nvidia-smi` polling with a lower-overhead GPU collector such as NVML.
 - Support multi-Instance comparison in one dashboard.
+
+## Integrated Instance Resource Dashboard
+
+`demo_instance.py` can optionally start the browser Resource Dashboard as part of the same Instance process:
+
+```bash
+python3 test/demo_instance.py --ui
+```
+
+With default settings, the Dashboard listens on `0.0.0.0:9202` and the usable local URL printed by the demo is:
+
+```text
+http://127.0.0.1:9202
+```
+
+The listen address `0.0.0.0` means the server accepts connections on all container or host interfaces. For local health checks and browser opening, `demo_instance.py` prints and opens `127.0.0.1` instead because wildcard addresses are not usable browser destinations. In containers without host networking, expose the Dashboard port, for example `-p 9202:9202`.
+
+To choose the Dashboard listen address:
+
+```bash
+python3 test/demo_instance.py \
+  --ui \
+  --ui-listen 0.0.0.0:9202
+```
+
+Explicit `--ui` opens the local default browser after the Dashboard is ready. In headless containers, remote shells, or CI, disable browser opening while still serving the Dashboard:
+
+```bash
+python3 test/demo_instance.py \
+  --ui \
+  --no-ui-open-browser
+```
+
+Use `--no-ui` to disable integrated Dashboard startup entirely, even if `INSTANCE_UI_ENABLE=1` is set. The related environment variables are `INSTANCE_UI_ENABLE`, `INSTANCE_UI_LISTEN`, `INSTANCE_UI_OPEN_BROWSER`, and `INSTANCE_UI_START_TIMEOUT_S`; explicit CLI options take precedence over environment values.
+
+Integrated mode connects the Dashboard to the same Resource Agent listen address and sample interval used by `demo_instance.py`. It always launches `instance/resource_dashboard/dashboard_server.py` with `--no-auto-start`, so `demo_instance.py` remains the only owner of the Resource Agent in the combined workflow. `demo_instance.py` also owns and cleans up only the Dashboard process it starts; if an already reachable Dashboard is reused, it is not terminated on Instance shutdown.
+
+Dashboard startup, readiness, and browser-opening failures are warnings only. They do not stop the Instance; check the `[demo_instance][ui]` log lines for the generated command, readiness timeout or early-exit reason, and bounded stdout/stderr tails.

--- a/test/README.md
+++ b/test/README.md
@@ -217,3 +217,41 @@ for p in /proc/[0-9]*; do
   fi
 done
 ```
+
+## Integrated Instance Resource Dashboard
+
+`demo_instance.py` can optionally start the browser Resource Dashboard as part of the same Instance process:
+
+```bash
+python3 test/demo_instance.py --ui
+```
+
+With default settings, the Dashboard listens on `0.0.0.0:9202` and the usable local URL printed by the demo is:
+
+```text
+http://127.0.0.1:9202
+```
+
+The listen address `0.0.0.0` means the server accepts connections on all container or host interfaces. For local health checks and browser opening, `demo_instance.py` prints and opens `127.0.0.1` instead because wildcard addresses are not usable browser destinations. In containers without host networking, expose the Dashboard port, for example `-p 9202:9202`.
+
+To choose the Dashboard listen address:
+
+```bash
+python3 test/demo_instance.py \
+  --ui \
+  --ui-listen 0.0.0.0:9202
+```
+
+Explicit `--ui` opens the local default browser after the Dashboard is ready. In headless containers, remote shells, or CI, disable browser opening while still serving the Dashboard:
+
+```bash
+python3 test/demo_instance.py \
+  --ui \
+  --no-ui-open-browser
+```
+
+Use `--no-ui` to disable integrated Dashboard startup entirely, even if `INSTANCE_UI_ENABLE=1` is set. The related environment variables are `INSTANCE_UI_ENABLE`, `INSTANCE_UI_LISTEN`, `INSTANCE_UI_OPEN_BROWSER`, and `INSTANCE_UI_START_TIMEOUT_S`; explicit CLI options take precedence over environment values.
+
+Integrated mode connects the Dashboard to the same Resource Agent listen address and sample interval used by `demo_instance.py`. It always launches `instance/resource_dashboard/dashboard_server.py` with `--no-auto-start`, so `demo_instance.py` remains the only owner of the Resource Agent in the combined workflow. `demo_instance.py` also owns and cleans up only the Dashboard process it starts; if an already reachable Dashboard is reused, it is not terminated on Instance shutdown.
+
+Dashboard startup, readiness, and browser-opening failures are warnings only. They do not stop the Instance; check the `[demo_instance][ui]` log lines for the generated command, readiness timeout or early-exit reason, and bounded stdout/stderr tails.

--- a/test/demo_instance.py
+++ b/test/demo_instance.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import sys
 import asyncio
@@ -133,18 +134,39 @@ class DemoDashboard:
             "--no-auto-start",
         ]
 
-    def _health_ok(self, timeout_s: float = 0.5) -> bool:
+    def _expected_agent_url(self) -> str:
+        return f"http://{self.agent_listen}"
+
+    def _compatible_health_payload(self, payload: dict, runtime_instance_id: str | None = None) -> bool:
+        if payload.get("ok") is not True or payload.get("dashboard") != "ok":
+            return False
+        agent = payload.get("agent")
+        if not isinstance(agent, dict):
+            return False
+        if agent.get("agent_url") != self._expected_agent_url():
+            return False
+        if int(agent.get("sample_interval_ms", -1)) != self.sample_interval_ms:
+            return False
+        if runtime_instance_id is not None and agent.get("instance_id") != runtime_instance_id:
+            return False
+        return True
+
+    def _health_ok(self, timeout_s: float = 0.5, runtime_instance_id: str | None = None) -> bool:
         try:
             req = urllib.request.Request(f"{self.url}/api/health", headers={"Accept": "application/json"})
             with urllib.request.urlopen(req, timeout=timeout_s) as resp:
-                return 200 <= int(resp.status) < 300
+                if not (200 <= int(resp.status) < 300):
+                    return False
+                body = resp.read().decode("utf-8")
+            payload = json.loads(body) if body else {}
+            return isinstance(payload, dict) and self._compatible_health_payload(payload, runtime_instance_id)
         except Exception:
             return False
 
-    async def _wait_ready(self, logger) -> bool:
+    async def _wait_ready(self, logger, runtime_instance_id: str) -> bool:
         deadline = time.monotonic() + max(0.0, self.start_timeout_s)
         while time.monotonic() <= deadline:
-            if await asyncio.to_thread(self._health_ok, 0.5):
+            if await asyncio.to_thread(self._health_ok, 0.5, runtime_instance_id):
                 logger.info("[demo_instance][ui] dashboard ready: %s", self.url)
                 return True
             if self._proc is not None and self._proc.poll() is not None:
@@ -164,8 +186,8 @@ class DemoDashboard:
         if not self.enabled:
             return
         cmd = self.build_command(runtime_instance_id)
-        if await asyncio.to_thread(self._health_ok, 0.5):
-            logger.info("[demo_instance][ui] reusing reachable Dashboard: %s", self.url)
+        if await asyncio.to_thread(self._health_ok, 0.5, runtime_instance_id):
+            logger.info("[demo_instance][ui] reusing compatible reachable Dashboard: %s", self.url)
             if self.open_browser:
                 await self._open_browser(logger)
             return
@@ -178,7 +200,7 @@ class DemoDashboard:
             return
         asyncio.create_task(asyncio.to_thread(DemoResourceMonitor._spawn_log_reader, self._proc.stdout, self._stdout_tail))
         asyncio.create_task(asyncio.to_thread(DemoResourceMonitor._spawn_log_reader, self._proc.stderr, self._stderr_tail))
-        if await self._wait_ready(logger):
+        if await self._wait_ready(logger, runtime_instance_id):
             print(f"[demo_instance] Resource Dashboard URL: {self.url}", flush=True)
             if self.open_browser:
                 await self._open_browser(logger)

--- a/test/demo_instance.py
+++ b/test/demo_instance.py
@@ -40,6 +40,10 @@ def _set_bool_env(name: str, enabled: bool) -> None:
     os.environ[name] = "1" if enabled else "0"
 
 
+def _interval_from_hz(hz: float) -> int:
+    return max(1, int(round(1000.0 / max(float(hz), 0.001))))
+
+
 def parse_listen(value: str) -> tuple[str, int]:
     raw = (value or "").strip()
     if raw.startswith("["):

--- a/test/demo_instance.py
+++ b/test/demo_instance.py
@@ -1,4 +1,3 @@
-import uvicorn
 import argparse
 import os
 import sys
@@ -8,6 +7,7 @@ import subprocess
 import shutil
 import time
 import urllib.request
+import webbrowser
 from collections import deque
 from pathlib import Path
 
@@ -15,8 +15,18 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.append(str(ROOT_DIR))
 
-from core import config
-from instance.resource_agent.proxy_reporter import report_once
+import importlib.util
+
+_config_spec = importlib.util.spec_from_file_location("cacheroute_core_config", ROOT_DIR / "core" / "config.py")
+config = importlib.util.module_from_spec(_config_spec)
+assert _config_spec.loader is not None
+_config_spec.loader.exec_module(config)
+
+_reporter_spec = importlib.util.spec_from_file_location("cacheroute_proxy_reporter", ROOT_DIR / "instance" / "resource_agent" / "proxy_reporter.py")
+_reporter = importlib.util.module_from_spec(_reporter_spec)
+assert _reporter_spec.loader is not None
+_reporter_spec.loader.exec_module(_reporter)
+report_once = _reporter.report_once
 
 
 def _env_flag(name: str, default: bool) -> bool:
@@ -30,8 +40,178 @@ def _set_bool_env(name: str, enabled: bool) -> None:
     os.environ[name] = "1" if enabled else "0"
 
 
-def _interval_from_hz(hz: float) -> int:
-    return max(1, int(round(1000.0 / max(float(hz), 0.001))))
+def parse_listen(value: str) -> tuple[str, int]:
+    raw = (value or "").strip()
+    if raw.startswith("["):
+        end = raw.find("]")
+        if end < 0 or end + 1 >= len(raw) or raw[end + 1] != ":":
+            raise argparse.ArgumentTypeError(f"listen address must be host:port, got {value!r}")
+        host = raw[1:end]
+        port_s = raw[end + 2:]
+    else:
+        if ":" not in raw:
+            raise argparse.ArgumentTypeError(f"listen address must be host:port, got {value!r}")
+        host, port_s = raw.rsplit(":", 1)
+    if not host:
+        host = "0.0.0.0"
+    try:
+        port = int(port_s)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid port in {value!r}") from exc
+    if port <= 0 or port > 65535:
+        raise argparse.ArgumentTypeError(f"port out of range in {value!r}")
+    return host, port
+
+
+def _reachable_host(host: str) -> str:
+    normalized = (host or "").strip().strip("[]")
+    if normalized in {"0.0.0.0", "::", ""}:
+        return "127.0.0.1"
+    return normalized
+
+
+def _url_host(host: str) -> str:
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
+def dashboard_url_for_listen(listen: str) -> str:
+    host, port = parse_listen(listen)
+    return f"http://{_url_host(_reachable_host(host))}:{port}"
+
+
+def resolve_ui_options(args: argparse.Namespace) -> argparse.Namespace:
+    env_ui = _env_flag("INSTANCE_UI_ENABLE", config.INSTANCE_UI_ENABLE)
+    ui_enabled = env_ui if args.ui is None else bool(args.ui)
+
+    env_browser = _env_flag("INSTANCE_UI_OPEN_BROWSER", config.INSTANCE_UI_OPEN_BROWSER)
+    if args.ui_open_browser is None:
+        open_browser = True if args.ui is True else env_browser
+    else:
+        open_browser = bool(args.ui_open_browser)
+
+    args.ui_enabled = ui_enabled
+    args.ui_open_browser_resolved = open_browser
+    parse_listen(args.ui_listen)
+    if float(args.ui_start_timeout_s) < 0:
+        raise argparse.ArgumentTypeError("--ui-start-timeout-s must be non-negative")
+    return args
+
+
+class DemoDashboard:
+    """Own browser Dashboard lifecycle for demo_instance.py integrated UI only."""
+
+    def __init__(self, *, enabled: bool, listen: str, open_browser: bool, start_timeout_s: float, agent_listen: str, sample_interval_ms: int) -> None:
+        self.enabled = enabled
+        self.listen = listen
+        self.open_browser = open_browser
+        self.start_timeout_s = float(start_timeout_s)
+        self.agent_listen = agent_listen
+        self.sample_interval_ms = int(sample_interval_ms)
+        self._proc = None
+        self._started_dashboard = False
+        self._stdout_tail: deque[str] = deque(maxlen=20)
+        self._stderr_tail: deque[str] = deque(maxlen=20)
+
+    @property
+    def url(self) -> str:
+        return dashboard_url_for_listen(self.listen)
+
+    def build_command(self, runtime_instance_id: str) -> list[str]:
+        return [
+            sys.executable,
+            str((ROOT_DIR / "instance" / "resource_dashboard" / "dashboard_server.py").resolve()),
+            "--dashboard-listen", self.listen,
+            "--agent-listen", self.agent_listen,
+            "--sample-interval-ms", str(self.sample_interval_ms),
+            "--instance-id", runtime_instance_id,
+            "--no-auto-start",
+        ]
+
+    def _health_ok(self, timeout_s: float = 0.5) -> bool:
+        try:
+            req = urllib.request.Request(f"{self.url}/api/health", headers={"Accept": "application/json"})
+            with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+                return 200 <= int(resp.status) < 300
+        except Exception:
+            return False
+
+    async def _wait_ready(self, logger) -> bool:
+        deadline = time.monotonic() + max(0.0, self.start_timeout_s)
+        while time.monotonic() <= deadline:
+            if await asyncio.to_thread(self._health_ok, 0.5):
+                logger.info("[demo_instance][ui] dashboard ready: %s", self.url)
+                return True
+            if self._proc is not None and self._proc.poll() is not None:
+                return False
+            await asyncio.sleep(0.2)
+        return False
+
+    async def _open_browser(self, logger) -> None:
+        try:
+            ok = await asyncio.to_thread(webbrowser.open, self.url)
+            if not ok:
+                logger.warning("[demo_instance][ui] browser open returned false for %s; use --no-ui-open-browser in headless environments", self.url)
+        except Exception as exc:
+            logger.warning("[demo_instance][ui] browser open failed for %s: %s", self.url, exc)
+
+    async def start(self, *, runtime_instance_id: str, logger) -> None:
+        if not self.enabled:
+            return
+        cmd = self.build_command(runtime_instance_id)
+        if await asyncio.to_thread(self._health_ok, 0.5):
+            logger.info("[demo_instance][ui] reusing reachable Dashboard: %s", self.url)
+            if self.open_browser:
+                await self._open_browser(logger)
+            return
+        logger.info("[demo_instance][ui] starting Dashboard: %s", " ".join(cmd))
+        try:
+            self._proc = subprocess.Popen(cmd, cwd=str(ROOT_DIR), stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)
+            self._started_dashboard = True
+        except Exception as exc:
+            logger.warning("[demo_instance][ui] failed to start Dashboard cmd=%s err=%s", " ".join(cmd), exc)
+            return
+        asyncio.create_task(asyncio.to_thread(DemoResourceMonitor._spawn_log_reader, self._proc.stdout, self._stdout_tail))
+        asyncio.create_task(asyncio.to_thread(DemoResourceMonitor._spawn_log_reader, self._proc.stderr, self._stderr_tail))
+        if await self._wait_ready(logger):
+            print(f"[demo_instance] Resource Dashboard URL: {self.url}", flush=True)
+            if self.open_browser:
+                await self._open_browser(logger)
+            return
+        returncode = self._proc.poll() if self._proc is not None else None
+        reason = "exited before readiness" if returncode is not None else f"readiness timeout after {self.start_timeout_s}s"
+        logger.warning(
+            "[demo_instance][ui] Dashboard startup failed: reason=%s cmd=%s returncode=%s stdout_tail=%r stderr_tail=%r",
+            reason, " ".join(cmd), returncode, DemoResourceMonitor._read_tail(self._stdout_tail), DemoResourceMonitor._read_tail(self._stderr_tail),
+        )
+
+    async def stop(self, logger) -> None:
+        if not self._started_dashboard or self._proc is None:
+            return
+        proc = self._proc
+        if proc.poll() is not None:
+            try:
+                await asyncio.to_thread(proc.wait, 0)
+            except Exception:
+                pass
+            self._started_dashboard = False
+            return
+        try:
+            logger.info("[demo_instance][ui] stopping Dashboard process group pid=%s", proc.pid)
+            os.killpg(proc.pid, signal.SIGTERM)
+            await asyncio.to_thread(proc.wait, 3)
+        except subprocess.TimeoutExpired:
+            try:
+                logger.warning("[demo_instance][ui] Dashboard did not stop after SIGTERM; sending SIGKILL pid=%s", proc.pid)
+                os.killpg(proc.pid, signal.SIGKILL)
+                await asyncio.to_thread(proc.wait, 3)
+            except Exception:
+                pass
+        except Exception as exc:
+            logger.debug("[demo_instance][ui] Dashboard cleanup ignored: %s", exc)
+        finally:
+            self._started_dashboard = False
 
 
 class DemoResourceMonitor:
@@ -217,6 +397,12 @@ class DemoResourceMonitor:
         else:
             logger.info("[demo_instance][resource] resource reporting disabled")
 
+    async def ensure_agent_for_ui(self, *, runtime_instance_id: str, logger) -> None:
+        if not self.enabled:
+            logger.warning("[demo_instance][ui] resource monitor disabled; Dashboard will reuse external agent if reachable")
+            return
+        await self._start_or_reuse_agent(runtime_instance_id, logger)
+
     def skip_after_registration_failure(self, logger) -> None:
         if self.enabled:
             logger.warning("[demo_instance][resource] reporting skipped because Instance registration to Proxy failed")
@@ -241,8 +427,7 @@ class DemoResourceMonitor:
             logger.debug("[demo_instance][resource] Resource Agent cleanup ignored: %s", exc)
 
 
-def main():
-    # ====== Start Instance service ======
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run CacheRoute Instance")
     parser.add_argument("--host", type=str, default=None, help="listen host (override config)")
     parser.add_argument("--port", type=int, default=None, help="listen port (override config)")
@@ -334,7 +519,37 @@ def main():
         help="HTTP timeout for resource reporting",
     )
     parser.add_argument("--proxy-cp-url", type=str, default=os.environ.get("PROXY_CP_URL", config.PROXY_CP_URL), help="Proxy control-plane URL for registration/reporting")
-    args = parser.parse_args()
+    parser.add_argument("--ui", dest="ui", action="store_true", default=None, help="auto-start the browser Resource Dashboard")
+    parser.add_argument("--no-ui", dest="ui", action="store_false", help="disable browser Resource Dashboard startup")
+    parser.add_argument(
+        "--ui-listen",
+        type=str,
+        default=os.environ.get("INSTANCE_UI_LISTEN", config.INSTANCE_UI_LISTEN),
+        help="Resource Dashboard listen address (host:port)",
+    )
+    parser.add_argument("--ui-open-browser", dest="ui_open_browser", action="store_true", default=None, help="open the Resource Dashboard URL after readiness")
+    parser.add_argument("--no-ui-open-browser", dest="ui_open_browser", action="store_false", help="do not open a browser for the Resource Dashboard")
+    parser.add_argument(
+        "--ui-start-timeout-s",
+        type=float,
+        default=float(os.environ.get("INSTANCE_UI_START_TIMEOUT_S", config.INSTANCE_UI_START_TIMEOUT_S)),
+        help="seconds to wait for Resource Dashboard readiness",
+    )
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return resolve_ui_options(args)
+    except argparse.ArgumentTypeError as exc:
+        parser.error(str(exc))
+
+
+def main():
+    # ====== Start Instance service ======
+    args = parse_args()
 
     # Defaults come from config/env; command-line values override them
     cfg_port = int(os.environ.get("INSTANCE_PORT", config.INSTANCE_PORT))
@@ -375,6 +590,10 @@ def main():
     os.environ["INSTANCE_RESOURCE_REPORT_HZ"] = str(args.resource_report_hz)
     os.environ["INSTANCE_RESOURCE_REPORT_INTERVAL_MS"] = str(report_interval_ms)
     os.environ["INSTANCE_RESOURCE_REPORT_TIMEOUT_S"] = str(args.resource_report_timeout_s)
+    _set_bool_env("INSTANCE_UI_ENABLE", args.ui_enabled)
+    _set_bool_env("INSTANCE_UI_OPEN_BROWSER", args.ui_open_browser_resolved)
+    os.environ["INSTANCE_UI_LISTEN"] = args.ui_listen
+    os.environ["INSTANCE_UI_START_TIMEOUT_S"] = str(args.ui_start_timeout_s)
 
     if monitor_enabled:
         print(
@@ -386,7 +605,17 @@ def main():
         )
     else:
         print("[demo_instance] resource monitor disabled", flush=True)
+    if args.ui_enabled:
+        print(
+            "[demo_instance] resource dashboard enabled: "
+            f"listen={args.ui_listen} url={dashboard_url_for_listen(args.ui_listen)} "
+            f"open_browser={args.ui_open_browser_resolved} timeout_s={args.ui_start_timeout_s}",
+            flush=True,
+        )
+    else:
+        print("[demo_instance] resource dashboard disabled", flush=True)
 
+    import uvicorn
     from instance import instance
     instance.state._demo_resource_monitor = DemoResourceMonitor(  # type: ignore
         enabled=monitor_enabled,
@@ -399,6 +628,14 @@ def main():
         report_interval_ms=report_interval_ms,
         report_timeout_s=args.resource_report_timeout_s,
         proxy_cp_url=args.proxy_cp_url,
+    )
+    instance.state._demo_dashboard = DemoDashboard(  # type: ignore
+        enabled=args.ui_enabled,
+        listen=args.ui_listen,
+        open_browser=args.ui_open_browser_resolved,
+        start_timeout_s=args.ui_start_timeout_s,
+        agent_listen=args.resource_agent_listen,
+        sample_interval_ms=args.resource_agent_sample_interval_ms,
     )
     uvicorn.run(instance, host=host, port=port, reload=False)
 

--- a/test/test_demo_instance_ui.py
+++ b/test/test_demo_instance_ui.py
@@ -14,40 +14,11 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-fake_config = types.SimpleNamespace(
-    INSTANCE_RESOURCE_MONITOR_ENABLE=True,
-    INSTANCE_RESOURCE_AUTO_START_AGENT=True,
-    INSTANCE_RESOURCE_AGENT_LISTEN="127.0.0.1:9201",
-    INSTANCE_RESOURCE_AGENT_URL="http://127.0.0.1:9201",
-    INSTANCE_RESOURCE_AGENT_SAMPLE_INTERVAL_MS=1000,
-    INSTANCE_RESOURCE_AGENT_START_TIMEOUT_S=60.0,
-    INSTANCE_RESOURCE_REPORT_ENABLE=False,
-    INSTANCE_RESOURCE_REPORT_HZ=1.0,
-    INSTANCE_RESOURCE_REPORT_TIMEOUT_S=2.0,
-    INSTANCE_UI_ENABLE=False,
-    INSTANCE_UI_LISTEN="0.0.0.0:9202",
-    INSTANCE_UI_OPEN_BROWSER=False,
-    INSTANCE_UI_START_TIMEOUT_S=5.0,
-    INSTANCE_PORT=9001,
-    INSTANCE_HOST="127.0.0.1",
-    PROXY_CP_URL="http://127.0.0.1:8002",
-)
-fake_core = types.ModuleType("core")
-fake_core.config = fake_config
-sys.modules.setdefault("core", fake_core)
-sys.modules.setdefault("core.config", fake_config)
-fake_uvicorn = types.ModuleType("uvicorn")
-fake_uvicorn.run = lambda *args, **kwargs: None
-sys.modules.setdefault("uvicorn", fake_uvicorn)
-fake_reporter = types.ModuleType("instance.resource_agent.proxy_reporter")
-fake_reporter.report_once = lambda *args, **kwargs: True
-sys.modules.setdefault("instance.resource_agent.proxy_reporter", fake_reporter)
-config = fake_config
-
 spec = importlib.util.spec_from_file_location("demo_instance", os.path.join(os.path.dirname(__file__), "demo_instance.py"))
 demo_instance = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(demo_instance)
+config = demo_instance.config
 
 
 def test_interval_from_hz_preserves_existing_conversion():
@@ -142,14 +113,125 @@ class Logger:
     def debug(self, *args): self.messages.append(("debug", args))
 
 
+class FakeHTTPResponse:
+    def __init__(self, status=200, body=''):
+        self.status = status
+        self._body = body.encode('utf-8')
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def dashboard_payload(*, agent_url="http://127.0.0.1:9201", sample_interval_ms=1000, instance_id="runtime-id"):
+    return {
+        "ok": True,
+        "dashboard": "ok",
+        "agent": {
+            "agent_url": agent_url,
+            "sample_interval_ms": sample_interval_ms,
+            "instance_id": instance_id,
+        },
+    }
+
+
+def dashboard_for_health() -> object:
+    return demo_instance.DemoDashboard(
+        enabled=True,
+        listen="127.0.0.1:9202",
+        open_browser=False,
+        start_timeout_s=0.1,
+        agent_listen="127.0.0.1:9201",
+        sample_interval_ms=1000,
+    )
+
+
+def test_health_ok_accepts_compatible_dashboard_json(monkeypatch):
+    d = dashboard_for_health()
+    monkeypatch.setattr(demo_instance.urllib.request, "urlopen", lambda req, timeout: FakeHTTPResponse(body=demo_instance.json.dumps(dashboard_payload())))
+    assert d._health_ok(runtime_instance_id="runtime-id") is True
+
+
+def test_health_ok_rejects_non_json_200(monkeypatch):
+    d = dashboard_for_health()
+    monkeypatch.setattr(demo_instance.urllib.request, "urlopen", lambda req, timeout: FakeHTTPResponse(body="not json"))
+    assert d._health_ok(runtime_instance_id="runtime-id") is False
+
+
+def test_health_ok_rejects_unrelated_200_service(monkeypatch):
+    d = dashboard_for_health()
+    monkeypatch.setattr(demo_instance.urllib.request, "urlopen", lambda req, timeout: FakeHTTPResponse(body=demo_instance.json.dumps({"ok": True})))
+    assert d._health_ok(runtime_instance_id="runtime-id") is False
+
+
+def test_health_ok_rejects_mismatched_agent_url(monkeypatch):
+    d = dashboard_for_health()
+    payload = dashboard_payload(agent_url="http://127.0.0.1:9999")
+    monkeypatch.setattr(demo_instance.urllib.request, "urlopen", lambda req, timeout: FakeHTTPResponse(body=demo_instance.json.dumps(payload)))
+    assert d._health_ok(runtime_instance_id="runtime-id") is False
+
+
+def test_health_ok_rejects_mismatched_sample_interval(monkeypatch):
+    d = dashboard_for_health()
+    payload = dashboard_payload(sample_interval_ms=250)
+    monkeypatch.setattr(demo_instance.urllib.request, "urlopen", lambda req, timeout: FakeHTTPResponse(body=demo_instance.json.dumps(payload)))
+    assert d._health_ok(runtime_instance_id="runtime-id") is False
+
+
+def test_health_ok_rejects_mismatched_instance_id(monkeypatch):
+    d = dashboard_for_health()
+    payload = dashboard_payload(instance_id="other-id")
+    monkeypatch.setattr(demo_instance.urllib.request, "urlopen", lambda req, timeout: FakeHTTPResponse(body=demo_instance.json.dumps(payload)))
+    assert d._health_ok(runtime_instance_id="runtime-id") is False
+
+
+
 def test_reuse_existing_dashboard_does_not_spawn_or_stop(monkeypatch):
     calls = []
     d = demo_instance.DemoDashboard(enabled=True, listen="127.0.0.1:9202", open_browser=False, start_timeout_s=0.1, agent_listen="127.0.0.1:9201", sample_interval_ms=1000)
-    monkeypatch.setattr(d, "_health_ok", lambda timeout_s=0.5: True)
+    monkeypatch.setattr(d, "_health_ok", lambda timeout_s=0.5, runtime_instance_id=None: True)
     monkeypatch.setattr(demo_instance.subprocess, "Popen", lambda *a, **k: calls.append((a, k)))
     asyncio.run(d.start(runtime_instance_id="id", logger=Logger()))
     asyncio.run(d.stop(logger=Logger()))
     assert calls == []
+
+
+def test_compatible_external_dashboard_reuse_validates_identity(monkeypatch):
+    d = dashboard_for_health()
+    popen_calls = []
+    monkeypatch.setattr(demo_instance.urllib.request, "urlopen", lambda req, timeout: FakeHTTPResponse(body=demo_instance.json.dumps(dashboard_payload())))
+    monkeypatch.setattr(demo_instance.subprocess, "Popen", lambda *a, **k: popen_calls.append((a, k)))
+
+    asyncio.run(d.start(runtime_instance_id="runtime-id", logger=Logger()))
+    asyncio.run(d.stop(logger=Logger()))
+
+    assert popen_calls == []
+    assert d._started_dashboard is False
+
+
+def test_incompatible_external_service_is_not_marked_reused(monkeypatch):
+    d = dashboard_for_health()
+    popen_calls = []
+    log = Logger()
+    monkeypatch.setattr(demo_instance.urllib.request, "urlopen", lambda req, timeout: FakeHTTPResponse(body=demo_instance.json.dumps({"ok": True})))
+
+    def fake_popen(*args, **kwargs):
+        popen_calls.append((args, kwargs))
+        raise OSError("address already in use")
+
+    monkeypatch.setattr(demo_instance.subprocess, "Popen", fake_popen)
+
+    asyncio.run(d.start(runtime_instance_id="runtime-id", logger=log))
+
+    assert popen_calls
+    assert d._started_dashboard is False
+    assert any(m[0] == "warning" and "failed to start Dashboard" in m[1][0] for m in log.messages)
+
 
 
 def test_start_timeout_nonfatal_and_bounded_tails(monkeypatch):
@@ -157,7 +239,7 @@ def test_start_timeout_nonfatal_and_bounded_tails(monkeypatch):
     fake = FakeProc()
     d._stdout_tail = deque([f"out{i}\n" for i in range(30)], maxlen=20)
     d._stderr_tail = deque([f"err{i}\n" for i in range(30)], maxlen=20)
-    monkeypatch.setattr(d, "_health_ok", lambda timeout_s=0.5: False)
+    monkeypatch.setattr(d, "_health_ok", lambda timeout_s=0.5, runtime_instance_id=None: False)
     monkeypatch.setattr(demo_instance.subprocess, "Popen", lambda *a, **k: fake)
     log = Logger()
     asyncio.run(d.start(runtime_instance_id="id", logger=log))
@@ -169,7 +251,7 @@ def test_start_timeout_nonfatal_and_bounded_tails(monkeypatch):
 def test_browser_open_success_failure_and_disabled(monkeypatch):
     opened = []
     d = demo_instance.DemoDashboard(enabled=True, listen="127.0.0.1:9202", open_browser=True, start_timeout_s=0.1, agent_listen="127.0.0.1:9201", sample_interval_ms=1000)
-    monkeypatch.setattr(d, "_health_ok", lambda timeout_s=0.5: len(opened) == 0)
+    monkeypatch.setattr(d, "_health_ok", lambda timeout_s=0.5, runtime_instance_id=None: len(opened) == 0)
     monkeypatch.setattr(demo_instance.webbrowser, "open", lambda url: opened.append(url) or False)
     log = Logger()
     asyncio.run(d.start(runtime_instance_id="id", logger=log))
@@ -200,19 +282,26 @@ def test_main_default_report_interval_initialization_uses_hz_without_name_error(
     fake_instance_module.instance = fake_instance_app
     run_calls = []
 
-    monkeypatch.setitem(sys.modules, "instance", fake_instance_module)
-    monkeypatch.setattr(fake_uvicorn, "run", lambda *args, **kwargs: run_calls.append((args, kwargs)))
-    monkeypatch.setattr(sys, "argv", ["demo_instance.py", "--no-resource-monitor", "--no-ui"])
-    monkeypatch.delenv("INSTANCE_RESOURCE_REPORT_INTERVAL_MS", raising=False)
-    monkeypatch.delenv("INSTANCE_RESOURCE_REPORT_HZ", raising=False)
-    monkeypatch.delenv("INSTANCE_ID", raising=False)
+    fake_uvicorn = types.ModuleType("uvicorn")
+    fake_uvicorn.run = lambda *args, **kwargs: run_calls.append((args, kwargs))
 
-    demo_instance.main()
+    with monkeypatch.context() as m:
+        m.setitem(sys.modules, "instance", fake_instance_module)
+        m.setitem(sys.modules, "uvicorn", fake_uvicorn)
+        m.setattr(sys, "argv", ["demo_instance.py", "--no-resource-monitor", "--no-ui"])
+        m.delenv("INSTANCE_RESOURCE_REPORT_INTERVAL_MS", raising=False)
+        m.delenv("INSTANCE_RESOURCE_REPORT_HZ", raising=False)
+        m.delenv("INSTANCE_ID", raising=False)
 
-    assert os.environ["INSTANCE_RESOURCE_REPORT_INTERVAL_MS"] == "1000"
-    assert run_calls
-    assert fake_instance_app.state._demo_resource_monitor.report_interval_ms == 1000
-    assert fake_instance_app.state._demo_dashboard.enabled is False
+        demo_instance.main()
+
+        assert os.environ["INSTANCE_RESOURCE_REPORT_INTERVAL_MS"] == "1000"
+        assert run_calls
+        assert fake_instance_app.state._demo_resource_monitor.report_interval_ms == 1000
+        assert fake_instance_app.state._demo_dashboard.enabled is False
+
+    assert sys.modules.get("instance") is not fake_instance_module
+    assert sys.modules.get("uvicorn") is not fake_uvicorn
 
 
 def test_resource_agent_for_ui_uses_monitor_owner_without_reporting(monkeypatch):

--- a/test/test_demo_instance_ui.py
+++ b/test/test_demo_instance_ui.py
@@ -50,6 +50,14 @@ assert spec.loader is not None
 spec.loader.exec_module(demo_instance)
 
 
+def test_interval_from_hz_preserves_existing_conversion():
+    assert demo_instance._interval_from_hz(1.0) == 1000
+    assert demo_instance._interval_from_hz(2.0) == 500
+    assert demo_instance._interval_from_hz(0.5) == 2000
+    assert demo_instance._interval_from_hz(0.0) == 1000000
+    assert demo_instance._interval_from_hz(0.0001) == 1000000
+
+
 def test_ui_disabled_by_default(monkeypatch):
     monkeypatch.delenv("INSTANCE_UI_ENABLE", raising=False)
     args = demo_instance.parse_args([])
@@ -186,14 +194,48 @@ def test_ui_disabled_creates_no_dashboard_process():
     assert d._proc is None
 
 
-def test_instance_lifecycle_starts_dashboard_outside_registration_success_branch():
-    source = (ROOT_DIR / "instance" / "instance_api.py").read_text()
-    assert "await dashboard.start(runtime_instance_id=runtime_instance_id, logger=logger)" in source
-    assert "if dashboard is not None:\n        await dashboard.start" in source
-    assert "await dashboard.stop(logger=logger)" in source
+def test_main_default_report_interval_initialization_uses_hz_without_name_error(monkeypatch):
+    fake_instance_app = types.SimpleNamespace(state=types.SimpleNamespace())
+    fake_instance_module = types.ModuleType("instance")
+    fake_instance_module.instance = fake_instance_app
+    run_calls = []
+
+    monkeypatch.setitem(sys.modules, "instance", fake_instance_module)
+    monkeypatch.setattr(fake_uvicorn, "run", lambda *args, **kwargs: run_calls.append((args, kwargs)))
+    monkeypatch.setattr(sys, "argv", ["demo_instance.py", "--no-resource-monitor", "--no-ui"])
+    monkeypatch.delenv("INSTANCE_RESOURCE_REPORT_INTERVAL_MS", raising=False)
+    monkeypatch.delenv("INSTANCE_RESOURCE_REPORT_HZ", raising=False)
+    monkeypatch.delenv("INSTANCE_ID", raising=False)
+
+    demo_instance.main()
+
+    assert os.environ["INSTANCE_RESOURCE_REPORT_INTERVAL_MS"] == "1000"
+    assert run_calls
+    assert fake_instance_app.state._demo_resource_monitor.report_interval_ms == 1000
+    assert fake_instance_app.state._demo_dashboard.enabled is False
 
 
-def test_resource_agent_for_ui_uses_monitor_owner_without_reporting():
-    source = (ROOT_DIR / "test" / "demo_instance.py").read_text()
-    assert "async def ensure_agent_for_ui" in source
-    assert "await self._start_or_reuse_agent(runtime_instance_id, logger)" in source
+def test_resource_agent_for_ui_uses_monitor_owner_without_reporting(monkeypatch):
+    calls = []
+    monitor = demo_instance.DemoResourceMonitor(
+        enabled=True,
+        auto_start_agent=True,
+        report_enabled=True,
+        agent_listen="127.0.0.1:9201",
+        agent_url="http://127.0.0.1:9201",
+        sample_interval_ms=1000,
+        start_timeout_s=1,
+        report_interval_ms=1000,
+        report_timeout_s=1,
+        proxy_cp_url="http://127.0.0.1:8002",
+    )
+
+    async def fake_start(runtime_instance_id, logger):
+        calls.append((runtime_instance_id, logger))
+        return True
+
+    monkeypatch.setattr(monitor, "_start_or_reuse_agent", fake_start)
+    asyncio.run(monitor.ensure_agent_for_ui(runtime_instance_id="runtime-id", logger=Logger()))
+
+    assert calls and calls[0][0] == "runtime-id"
+    assert monitor._report_task is None

--- a/test/test_demo_instance_ui.py
+++ b/test/test_demo_instance_ui.py
@@ -1,0 +1,199 @@
+import asyncio
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+import types
+from collections import deque
+
+import importlib.util
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+fake_config = types.SimpleNamespace(
+    INSTANCE_RESOURCE_MONITOR_ENABLE=True,
+    INSTANCE_RESOURCE_AUTO_START_AGENT=True,
+    INSTANCE_RESOURCE_AGENT_LISTEN="127.0.0.1:9201",
+    INSTANCE_RESOURCE_AGENT_URL="http://127.0.0.1:9201",
+    INSTANCE_RESOURCE_AGENT_SAMPLE_INTERVAL_MS=1000,
+    INSTANCE_RESOURCE_AGENT_START_TIMEOUT_S=60.0,
+    INSTANCE_RESOURCE_REPORT_ENABLE=False,
+    INSTANCE_RESOURCE_REPORT_HZ=1.0,
+    INSTANCE_RESOURCE_REPORT_TIMEOUT_S=2.0,
+    INSTANCE_UI_ENABLE=False,
+    INSTANCE_UI_LISTEN="0.0.0.0:9202",
+    INSTANCE_UI_OPEN_BROWSER=False,
+    INSTANCE_UI_START_TIMEOUT_S=5.0,
+    INSTANCE_PORT=9001,
+    INSTANCE_HOST="127.0.0.1",
+    PROXY_CP_URL="http://127.0.0.1:8002",
+)
+fake_core = types.ModuleType("core")
+fake_core.config = fake_config
+sys.modules.setdefault("core", fake_core)
+sys.modules.setdefault("core.config", fake_config)
+fake_uvicorn = types.ModuleType("uvicorn")
+fake_uvicorn.run = lambda *args, **kwargs: None
+sys.modules.setdefault("uvicorn", fake_uvicorn)
+fake_reporter = types.ModuleType("instance.resource_agent.proxy_reporter")
+fake_reporter.report_once = lambda *args, **kwargs: True
+sys.modules.setdefault("instance.resource_agent.proxy_reporter", fake_reporter)
+config = fake_config
+
+spec = importlib.util.spec_from_file_location("demo_instance", os.path.join(os.path.dirname(__file__), "demo_instance.py"))
+demo_instance = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(demo_instance)
+
+
+def test_ui_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("INSTANCE_UI_ENABLE", raising=False)
+    args = demo_instance.parse_args([])
+    assert args.ui_enabled is False
+
+
+def test_ui_flags_and_env_precedence(monkeypatch):
+    monkeypatch.setenv("INSTANCE_UI_ENABLE", "1")
+    assert demo_instance.parse_args(["--no-ui"]).ui_enabled is False
+    assert demo_instance.parse_args(["--ui"]).ui_enabled is True
+    monkeypatch.setenv("INSTANCE_UI_LISTEN", "127.0.0.1:12345")
+    monkeypatch.setenv("INSTANCE_UI_START_TIMEOUT_S", "9")
+    args = demo_instance.parse_args(["--ui-listen", "127.0.0.1:23456", "--ui-start-timeout-s", "1.5"])
+    assert args.ui_listen == "127.0.0.1:23456"
+    assert args.ui_start_timeout_s == 1.5
+
+
+def test_browser_open_resolution(monkeypatch):
+    monkeypatch.delenv("INSTANCE_UI_OPEN_BROWSER", raising=False)
+    assert demo_instance.parse_args(["--ui"]).ui_open_browser_resolved is True
+    assert demo_instance.parse_args(["--ui", "--no-ui-open-browser"]).ui_open_browser_resolved is False
+    assert demo_instance.parse_args(["--ui-open-browser"]).ui_open_browser_resolved is True
+    monkeypatch.setenv("INSTANCE_UI_ENABLE", "1")
+    monkeypatch.setenv("INSTANCE_UI_OPEN_BROWSER", "0")
+    assert demo_instance.parse_args([]).ui_open_browser_resolved is False
+
+
+def test_invalid_ui_listen_fails():
+    with pytest.raises(SystemExit):
+        demo_instance.parse_args(["--ui-listen", "bad"])
+
+
+def test_dashboard_command_uses_runtime_values():
+    d = demo_instance.DemoDashboard(
+        enabled=True,
+        listen="0.0.0.0:9202",
+        open_browser=False,
+        start_timeout_s=5,
+        agent_listen="127.0.0.1:19201",
+        sample_interval_ms=250,
+    )
+    cmd = d.build_command("runtime-id")
+    assert cmd[0] == sys.executable
+    assert cmd[1].endswith("instance/resource_dashboard/dashboard_server.py")
+    assert "--no-auto-start" in cmd
+    assert cmd[cmd.index("--agent-listen") + 1] == "127.0.0.1:19201"
+    assert cmd[cmd.index("--sample-interval-ms") + 1] == "250"
+    assert cmd[cmd.index("--instance-id") + 1] == "runtime-id"
+    assert cmd[cmd.index("--dashboard-listen") + 1] == "0.0.0.0:9202"
+
+
+def test_dashboard_url_maps_wildcard_hosts():
+    assert demo_instance.dashboard_url_for_listen("0.0.0.0:9202") == "http://127.0.0.1:9202"
+    assert demo_instance.dashboard_url_for_listen("[::]:9202") == "http://127.0.0.1:9202"
+    assert demo_instance.dashboard_url_for_listen("::1:9202") == "http://[::1]:9202"
+
+
+class FakeProc:
+    def __init__(self, poll_values=None):
+        self.pid = 4321
+        self.stdout = None
+        self.stderr = None
+        self.wait_calls = []
+        self._poll_values = list(poll_values or [None])
+
+    def poll(self):
+        return self._poll_values[0] if self._poll_values else None
+
+    def wait(self, timeout=None):
+        self.wait_calls.append(timeout)
+        if timeout == 3 and len(self.wait_calls) == 1:
+            raise subprocess.TimeoutExpired("cmd", timeout)
+        self._poll_values = [0]
+        return 0
+
+
+class Logger:
+    def __init__(self):
+        self.messages = []
+    def info(self, *args): self.messages.append(("info", args))
+    def warning(self, *args): self.messages.append(("warning", args))
+    def debug(self, *args): self.messages.append(("debug", args))
+
+
+def test_reuse_existing_dashboard_does_not_spawn_or_stop(monkeypatch):
+    calls = []
+    d = demo_instance.DemoDashboard(enabled=True, listen="127.0.0.1:9202", open_browser=False, start_timeout_s=0.1, agent_listen="127.0.0.1:9201", sample_interval_ms=1000)
+    monkeypatch.setattr(d, "_health_ok", lambda timeout_s=0.5: True)
+    monkeypatch.setattr(demo_instance.subprocess, "Popen", lambda *a, **k: calls.append((a, k)))
+    asyncio.run(d.start(runtime_instance_id="id", logger=Logger()))
+    asyncio.run(d.stop(logger=Logger()))
+    assert calls == []
+
+
+def test_start_timeout_nonfatal_and_bounded_tails(monkeypatch):
+    d = demo_instance.DemoDashboard(enabled=True, listen="127.0.0.1:9202", open_browser=False, start_timeout_s=0.01, agent_listen="127.0.0.1:9201", sample_interval_ms=1000)
+    fake = FakeProc()
+    d._stdout_tail = deque([f"out{i}\n" for i in range(30)], maxlen=20)
+    d._stderr_tail = deque([f"err{i}\n" for i in range(30)], maxlen=20)
+    monkeypatch.setattr(d, "_health_ok", lambda timeout_s=0.5: False)
+    monkeypatch.setattr(demo_instance.subprocess, "Popen", lambda *a, **k: fake)
+    log = Logger()
+    asyncio.run(d.start(runtime_instance_id="id", logger=log))
+    assert d._started_dashboard is True
+    assert "out0" not in demo_instance.DemoResourceMonitor._read_tail(d._stdout_tail)
+    assert any(m[0] == "warning" for m in log.messages)
+
+
+def test_browser_open_success_failure_and_disabled(monkeypatch):
+    opened = []
+    d = demo_instance.DemoDashboard(enabled=True, listen="127.0.0.1:9202", open_browser=True, start_timeout_s=0.1, agent_listen="127.0.0.1:9201", sample_interval_ms=1000)
+    monkeypatch.setattr(d, "_health_ok", lambda timeout_s=0.5: len(opened) == 0)
+    monkeypatch.setattr(demo_instance.webbrowser, "open", lambda url: opened.append(url) or False)
+    log = Logger()
+    asyncio.run(d.start(runtime_instance_id="id", logger=log))
+    assert opened == ["http://127.0.0.1:9202"]
+    assert any(m[0] == "warning" for m in log.messages)
+
+
+def test_cleanup_terminates_process_group_and_escalates(monkeypatch):
+    d = demo_instance.DemoDashboard(enabled=True, listen="127.0.0.1:9202", open_browser=False, start_timeout_s=0.1, agent_listen="127.0.0.1:9201", sample_interval_ms=1000)
+    d._proc = FakeProc()
+    d._started_dashboard = True
+    signals = []
+    monkeypatch.setattr(demo_instance.os, "killpg", lambda pid, sig: signals.append((pid, sig)))
+    asyncio.run(d.stop(logger=Logger()))
+    assert signals == [(4321, signal.SIGTERM), (4321, signal.SIGKILL)]
+    asyncio.run(d.stop(logger=Logger()))
+
+
+def test_ui_disabled_creates_no_dashboard_process():
+    d = demo_instance.DemoDashboard(enabled=False, listen=config.INSTANCE_UI_LISTEN, open_browser=False, start_timeout_s=1, agent_listen="127.0.0.1:9201", sample_interval_ms=1000)
+    assert d.enabled is False
+    assert d._proc is None
+
+
+def test_instance_lifecycle_starts_dashboard_outside_registration_success_branch():
+    source = (ROOT_DIR / "instance" / "instance_api.py").read_text()
+    assert "await dashboard.start(runtime_instance_id=runtime_instance_id, logger=logger)" in source
+    assert "if dashboard is not None:\n        await dashboard.start" in source
+    assert "await dashboard.stop(logger=logger)" in source
+
+
+def test_resource_agent_for_ui_uses_monitor_owner_without_reporting():
+    source = (ROOT_DIR / "test" / "demo_instance.py").read_text()
+    assert "async def ensure_agent_for_ui" in source
+    assert "await self._start_or_reuse_agent(runtime_instance_id, logger)" in source


### PR DESCRIPTION
### Motivation

- Provide an optional integrated browser Resource Dashboard for `demo_instance.py` so a single command can start the Instance and the dashboard for local demos and debugging.
- Keep demo behavior backward-compatible and preserve the demo process as the owner of any started Resource Agent and Dashboard processes.

### Description

- Add four config defaults in `core/config.py`: `INSTANCE_UI_ENABLE`, `INSTANCE_UI_LISTEN`, `INSTANCE_UI_OPEN_BROWSER`, and `INSTANCE_UI_START_TIMEOUT_S` to centralize UI defaults.
- Extend `test/demo_instance.py` with CLI options `--ui/--no-ui`, `--ui-listen`, `--ui-open-browser/--no-ui-open-browser`, and `--ui-start-timeout-s`, deterministic CLI/env/default resolution, listen parsing, wildcard->127.0.0.1 mapping, and environment propagation.
- Implement `DemoDashboard` inside `test/demo_instance.py` to construct the dashboard subprocess command (using `sys.executable` and an absolute script path), probe `/api/health` for reuse/readiness, open browser via `asyncio.to_thread(webbrowser.open)`, and manage a started process group with SIGTERM->SIGKILL escalation and bounded stdout/stderr tails.
- Integrate the dashboard lifecycle into `instance/instance_api.py` so the Dashboard is started after Instance local lifecycle initialization (not gated on successful Proxy registration) and stopped before resource-monitor cleanup; reuse of an external dashboard is honored and not terminated.
- Update documentation in `test/README.md` and `instance/resource_dashboard/README.md` and add focused unit tests `test/test_demo_instance_ui.py` covering CLI/env precedence, command construction, URL mapping, readiness behavior, browser handling, and cleanup semantics.
- Closes #134

### Testing

- Compiled the modified entrypoints with `python3 -m py_compile test/demo_instance.py instance/resource_dashboard/dashboard_server.py` which passed.
- Ran the new focused unit tests with `pytest -q test/test_demo_instance_ui.py` which passed: `13 passed`.
- Performed a smoke check by launching `instance/resource_dashboard/dashboard_server.py --dashboard-listen 127.0.0.1:39202 --agent-listen 127.0.0.1:39201 --sample-interval-ms 1000 --instance-id smoke --no-auto-start` and verified `GET /api/health` returned HTTP 200.
- Ran `python3 test/demo_instance.py --help` to validate CLI output which succeeded, and attempted a full `pytest -q` which failed during collection due to missing environment test dependencies (`uvicorn`, `requests`, `numpy`) that pre-existed in the repository test matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6315c44ccc83209ca851bce8afcaa3)