### PR TITLE
v0.1.10: add instance capability fingerprints

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+"""Keep repository packages importable when pytest is launched via its console script."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,20 +1,6 @@
-"""Public exports for CacheRoute core helpers, loaded only when requested."""
-from importlib import import_module
+"""Public exports for CacheRoute core request, tokenizer, model, and forwarding helpers."""
 
-
-_EXPORTS = {
-    "MLAmodel": (".model_calculation", "MLAmodel"),
-    "Request": (".request", "Request"), "Prompt": (".request", "Prompt"),
-    "Service": (".request", "Service"), "Task": (".request", "Task"),
-    "TokenizerRegistry": (".tokenizer_registry", "TokenizerRegistry"),
-    "forward_request": (".fwd", "forward_request"),
-}
-
-
-def __getattr__(name):
-    if name not in _EXPORTS:
-        raise AttributeError(name)
-    module_name, attribute = _EXPORTS[name]
-    value = getattr(import_module(module_name, __name__), attribute)
-    globals()[name] = value
-    return value
+from .model_calculation import MLAmodel
+from .request import Request, Prompt, Service, Task
+from .tokenizer_registry import TokenizerRegistry
+from .fwd import forward_request

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,6 +1,20 @@
-"""Public exports for CacheRoute core request, tokenizer, model, and forwarding helpers."""
+"""Public exports for CacheRoute core helpers, loaded only when requested."""
+from importlib import import_module
 
-from .model_calculation import MLAmodel
-from .request import Request, Prompt, Service, Task
-from .tokenizer_registry import TokenizerRegistry
-from .fwd import forward_request
+
+_EXPORTS = {
+    "MLAmodel": (".model_calculation", "MLAmodel"),
+    "Request": (".request", "Request"), "Prompt": (".request", "Prompt"),
+    "Service": (".request", "Service"), "Task": (".request", "Task"),
+    "TokenizerRegistry": (".tokenizer_registry", "TokenizerRegistry"),
+    "forward_request": (".fwd", "forward_request"),
+}
+
+
+def __getattr__(name):
+    if name not in _EXPORTS:
+        raise AttributeError(name)
+    module_name, attribute = _EXPORTS[name]
+    value = getattr(import_module(module_name, __name__), attribute)
+    globals()[name] = value
+    return value

--- a/core/instance_capability.py
+++ b/core/instance_capability.py
@@ -1,0 +1,153 @@
+"""Typed instance capability contract and deterministic compatibility helpers."""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CapabilityModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ModelCapability(CapabilityModel):
+    identifier: Optional[str] = None
+    revision: Optional[str] = None
+
+
+class AdapterCapability(CapabilityModel):
+    identifier: str
+    revision: Optional[str] = None
+    configuration: Optional[Dict[str, Any]] = None
+    configuration_hash: Optional[str] = None
+
+
+class KVCacheCapability(CapabilityModel):
+    layout: Optional[str] = None
+    schema_version: Optional[str] = None
+    dtype: Optional[str] = None
+    block_size: Optional[int] = Field(default=None, gt=0)
+    layout_parameters: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ParallelismCapability(CapabilityModel):
+    tensor_parallel_size: Optional[int] = Field(default=None, gt=0)
+    pipeline_parallel_size: Optional[int] = Field(default=None, gt=0)
+    data_parallel_size: Optional[int] = Field(default=None, gt=0)
+
+
+class RuntimeCapability(CapabilityModel):
+    vllm_version: Optional[str] = None
+    lmcache_version: Optional[str] = None
+    supported_cache_features: List[str] = Field(default_factory=list)
+
+
+class InstanceCapability(CapabilityModel):
+    schema_version: str = "1"
+    model: ModelCapability = Field(default_factory=ModelCapability)
+    tokenizer: ModelCapability = Field(default_factory=ModelCapability)
+    adapters: List[AdapterCapability] = Field(default_factory=list)
+    kv_cache: KVCacheCapability = Field(default_factory=KVCacheCapability)
+    parallelism: ParallelismCapability = Field(default_factory=ParallelismCapability)
+    runtime: RuntimeCapability = Field(default_factory=RuntimeCapability)
+
+
+def canonical_capability_dict(capability: InstanceCapability | Dict[str, Any]) -> Dict[str, Any]:
+    """Return compatibility data with stable set-like feature ordering.
+
+    Pydantic validation removes ambiguity in scalar representations. ``exclude_none``
+    gives absent optional values one representation, while adapter order remains intact.
+    """
+    value = capability if isinstance(capability, InstanceCapability) else InstanceCapability.model_validate(capability)
+    data = value.model_dump(mode="json", exclude_none=True)
+    features = data.get("runtime", {}).get("supported_cache_features")
+    if features is not None:
+        data["runtime"]["supported_cache_features"] = sorted(set(features))
+    return data
+
+
+def canonical_capability_json(capability: InstanceCapability | Dict[str, Any]) -> str:
+    return json.dumps(
+        canonical_capability_dict(capability), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+def capability_fingerprint(capability: InstanceCapability | Dict[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_capability_json(capability).encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+class CompatibilityMismatch(CapabilityModel):
+    field: str
+    left: Any = None
+    right: Any = None
+    reason: Literal["value_mismatch", "missing_value"]
+
+
+class CompatibilityResult(CapabilityModel):
+    status: Literal["compatible", "incompatible", "unknown"]
+    compatible: bool
+    left_fingerprint: Optional[str] = None
+    right_fingerprint: Optional[str] = None
+    mismatches: List[CompatibilityMismatch] = Field(default_factory=list)
+
+
+_COMPATIBILITY_PATHS = (
+    "schema_version",
+    "model.identifier", "model.revision",
+    "tokenizer.identifier", "tokenizer.revision",
+    "adapters", "kv_cache.layout", "kv_cache.schema_version", "kv_cache.dtype",
+    "kv_cache.block_size", "kv_cache.layout_parameters",
+    "parallelism.tensor_parallel_size", "parallelism.pipeline_parallel_size",
+    "parallelism.data_parallel_size", "runtime.vllm_version", "runtime.lmcache_version",
+    "runtime.supported_cache_features",
+)
+
+
+def _at(data: Dict[str, Any], path: str) -> Any:
+    value: Any = data
+    for part in path.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return None
+        value = value[part]
+    return value
+
+
+def compare_capabilities(
+    left: Optional[InstanceCapability | Dict[str, Any]],
+    right: Optional[InstanceCapability | Dict[str, Any]],
+) -> CompatibilityResult:
+    """Compare capabilities without treating incomplete legacy data as compatible."""
+    if left is None or right is None:
+        return CompatibilityResult(status="unknown", compatible=False)
+    left_model = left if isinstance(left, InstanceCapability) else InstanceCapability.model_validate(left)
+    right_model = right if isinstance(right, InstanceCapability) else InstanceCapability.model_validate(right)
+    left_data = canonical_capability_dict(left_model)
+    right_data = canonical_capability_dict(right_model)
+    mismatches: List[CompatibilityMismatch] = []
+    missing = False
+    for path in _COMPATIBILITY_PATHS:
+        left_value, right_value = _at(left_data, path), _at(right_data, path)
+        if left_value is None or right_value is None:
+            missing = True
+            if left_value != right_value:
+                mismatches.append(CompatibilityMismatch(
+                    field=path, left=left_value, right=right_value, reason="missing_value"
+                ))
+        elif left_value != right_value:
+            mismatches.append(CompatibilityMismatch(
+                field=path, left=left_value, right=right_value, reason="value_mismatch"
+            ))
+    left_fp, right_fp = capability_fingerprint(left_model), capability_fingerprint(right_model)
+    if any(item.reason == "value_mismatch" for item in mismatches):
+        status = "incompatible"
+    elif missing:
+        status = "unknown"
+    else:
+        status = "compatible"
+    return CompatibilityResult(
+        status=status, compatible=status == "compatible", left_fingerprint=left_fp,
+        right_fingerprint=right_fp, mismatches=mismatches,
+    )

--- a/instance/README.md
+++ b/instance/README.md
@@ -482,3 +482,22 @@ Not yet implemented:
 - detailed vLLM runtime queue metrics;
 - detailed KVCache block residency metrics;
 - lower-overhead GPU collection through NVML or a similar API.
+# Instance capability registration
+
+At startup, the Instance builds a typed capability description without loading a
+model or contacting an external service. It sends the complete object during
+registration and sends only the accepted/local `capability_fingerprint` on normal
+heartbeats. The fingerprint is `sha256:` plus the digest of compact, key-sorted
+canonical JSON. Supported-cache-feature order is set-like; adapter-stack order is
+preserved because it can affect behavior. Missing packages produce null runtime
+versions and do not prevent mock startup.
+
+Configuration precedence is an explicit environment override, existing CacheRoute
+configuration, safely detected package metadata, then null. Supported variables are
+`INSTANCE_MODEL_ID`, `INSTANCE_MODEL_REVISION`, `INSTANCE_TOKENIZER_ID`,
+`INSTANCE_TOKENIZER_REVISION`, `INSTANCE_ADAPTERS_JSON`, `INSTANCE_KV_LAYOUT`,
+`INSTANCE_KV_SCHEMA_VERSION`, `INSTANCE_KV_DTYPE`, `INSTANCE_KV_BLOCK_SIZE`,
+`INSTANCE_TENSOR_PARALLEL_SIZE`, `INSTANCE_PIPELINE_PARALLEL_SIZE`,
+`INSTANCE_DATA_PARALLEL_SIZE`, `INSTANCE_VLLM_VERSION`,
+`INSTANCE_LMCACHE_VERSION`, and comma-separated `INSTANCE_CACHE_FEATURES`.
+`INSTANCE_ADAPTERS_JSON` must be a JSON array of adapter objects.

--- a/instance/README.md
+++ b/instance/README.md
@@ -492,6 +492,12 @@ canonical JSON. Supported-cache-feature order is set-like; adapter-stack order i
 preserved because it can affect behavior. Missing packages produce null runtime
 versions and do not prevent mock startup.
 
+A new registration replaces any capability state previously stored under the same
+Instance ID; omitting capabilities there clears the old state. A heartbeat that
+omits capability fields instead preserves that state. If the Proxy rejects a
+fingerprint-only heartbeat as unknown or mismatched, the Instance may resend its
+complete capability object to resolve the mismatch.
+
 Configuration precedence is an explicit environment override, existing CacheRoute
 configuration, safely detected package metadata, then null. Supported variables are
 `INSTANCE_MODEL_ID`, `INSTANCE_MODEL_REVISION`, `INSTANCE_TOKENIZER_ID`,

--- a/instance/__init__.py
+++ b/instance/__init__.py
@@ -1,13 +1,3 @@
-"""Public Instance exports, loaded lazily to keep helper modules lightweight."""
-from importlib import import_module
-
-
-def __getattr__(name):
-    if name == "instance":
-        value = import_module(".instance_api", __name__).instance
-    elif name in {"mock_chat_stream", "mock_chat_completion", "mock_text_completion"}:
-        value = getattr(import_module(".mock_resp", __name__), name)
-    else:
-        raise AttributeError(name)
-    globals()[name] = value
-    return value
+"""Public Instance app and mock response exports."""
+from .instance_api import instance
+from .mock_resp import mock_chat_stream, mock_chat_completion, mock_text_completion

--- a/instance/__init__.py
+++ b/instance/__init__.py
@@ -1,3 +1,13 @@
-"""Public Instance app and mock response exports."""
-from .instance_api import instance
-from .mock_resp import mock_chat_stream, mock_chat_completion, mock_text_completion
+"""Public Instance exports, loaded lazily to keep helper modules lightweight."""
+from importlib import import_module
+
+
+def __getattr__(name):
+    if name == "instance":
+        value = import_module(".instance_api", __name__).instance
+    elif name in {"mock_chat_stream", "mock_chat_completion", "mock_text_completion"}:
+        value = getattr(import_module(".mock_resp", __name__), name)
+    else:
+        raise AttributeError(name)
+    globals()[name] = value
+    return value

--- a/instance/capability_builder.py
+++ b/instance/capability_builder.py
@@ -1,0 +1,77 @@
+"""Build instance capabilities without loading models or importing serving runtimes."""
+from __future__ import annotations
+
+import json
+import os
+from importlib import metadata
+from typing import Any, Optional
+
+from core import config
+from core.instance_capability import (
+    AdapterCapability, InstanceCapability, KVCacheCapability, ModelCapability,
+    ParallelismCapability, RuntimeCapability,
+)
+
+
+def _optional(name: str, configured: Any = None) -> Optional[str]:
+    value = os.environ.get(name)
+    if value is None:
+        value = configured
+    text = str(value).strip() if value is not None else ""
+    return text or None
+
+
+def _positive_int(name: str, configured: Any = None) -> Optional[int]:
+    value = _optional(name, configured)
+    if value is None:
+        return None
+    number = int(value)
+    if number <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return number
+
+
+def _package_version(distribution: str) -> Optional[str]:
+    try:
+        return metadata.version(distribution)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _adapters() -> list[AdapterCapability]:
+    raw = _optional("INSTANCE_ADAPTERS_JSON")
+    if raw is None:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("INSTANCE_ADAPTERS_JSON must contain valid JSON") from exc
+    if not isinstance(parsed, list):
+        raise ValueError("INSTANCE_ADAPTERS_JSON must contain a JSON array")
+    return [AdapterCapability.model_validate(item) for item in parsed]
+
+
+def build_instance_capability() -> InstanceCapability:
+    """Build with precedence: environment, CacheRoute config, detected version, null."""
+    model_id = _optional("INSTANCE_MODEL_ID", getattr(config, "DEFAULT_MODEL", None))
+    tokenizer_id = _optional("INSTANCE_TOKENIZER_ID", model_id)
+    features = [item.strip() for item in (_optional("INSTANCE_CACHE_FEATURES") or "").split(",") if item.strip()]
+    return InstanceCapability(
+        model=ModelCapability(identifier=model_id, revision=_optional("INSTANCE_MODEL_REVISION")),
+        tokenizer=ModelCapability(identifier=tokenizer_id, revision=_optional("INSTANCE_TOKENIZER_REVISION")),
+        adapters=_adapters(),
+        kv_cache=KVCacheCapability(
+            layout=_optional("INSTANCE_KV_LAYOUT"), schema_version=_optional("INSTANCE_KV_SCHEMA_VERSION"),
+            dtype=_optional("INSTANCE_KV_DTYPE"), block_size=_positive_int("INSTANCE_KV_BLOCK_SIZE"),
+        ),
+        parallelism=ParallelismCapability(
+            tensor_parallel_size=_positive_int("INSTANCE_TENSOR_PARALLEL_SIZE"),
+            pipeline_parallel_size=_positive_int("INSTANCE_PIPELINE_PARALLEL_SIZE"),
+            data_parallel_size=_positive_int("INSTANCE_DATA_PARALLEL_SIZE"),
+        ),
+        runtime=RuntimeCapability(
+            vllm_version=_optional("INSTANCE_VLLM_VERSION") or _package_version("vllm"),
+            lmcache_version=_optional("INSTANCE_LMCACHE_VERSION") or _package_version("lmcache"),
+            supported_cache_features=features,
+        ),
+    )

--- a/instance/instance_api.py
+++ b/instance/instance_api.py
@@ -32,6 +32,8 @@ from .mock_resp import (mock_text_completion,
 from util import parse_stream_flag
 from instance import control_plane
 from instance.pclient.proxy_client import ProxyControlClient
+from instance.capability_builder import build_instance_capability
+from core.instance_capability import capability_fingerprint
 
 
 PROXY_CP_URL = os.environ.get("PROXY_CP_URL", config.PROXY_CP_URL).rstrip("/")
@@ -167,6 +169,8 @@ async def lifespan(app: FastAPI):
     cp_host = os.environ.get("INSTANCE_CP_HOST", config.INSTANCE_CP_HOST)
     cp_port = int(os.environ.get("INSTANCE_CP_PORT", config.INSTANCE_CP_PORT))
     logger = logging.getLogger("instance")
+    capabilities = build_instance_capability()
+    local_capability_fingerprint = capability_fingerprint(capabilities)
 
     cp_config = uvicorn.Config(
         control_plane.control_plane,
@@ -190,6 +194,8 @@ async def lifespan(app: FastAPI):
             port=INSTANCE_ADVERTISE_PORT,
             endpoints=["chat/completions", "completions"],
             meta={"version": "instance_v1"},
+            capabilities=capabilities,
+            capability_fingerprint=local_capability_fingerprint,
         )
         runtime_instance_id = reg.instance_id
         interval = float(reg.heartbeat_interval_s) if reg.heartbeat_interval_s else 10.0
@@ -208,7 +214,7 @@ async def lifespan(app: FastAPI):
         fail = 0
         while not stop.is_set():
             try:
-                await client.heartbeat(runtime_instance_id)
+                await client.heartbeat(runtime_instance_id, capability_fingerprint=local_capability_fingerprint)
                 fail = 0
             except Exception as e:
                 fail += 1
@@ -425,4 +431,3 @@ async def instance_completions(request: FastAPIRequest):
 
     resp_json = await _vllm_text_completion(payload)
     return JSONResponse(content=resp_json)
-

--- a/instance/instance_api.py
+++ b/instance/instance_api.py
@@ -214,7 +214,14 @@ async def lifespan(app: FastAPI):
         fail = 0
         while not stop.is_set():
             try:
-                await client.heartbeat(runtime_instance_id, capability_fingerprint=local_capability_fingerprint)
+                heartbeat_result = await client.heartbeat(
+                    runtime_instance_id,
+                    capability_fingerprint=local_capability_fingerprint,
+                )
+                if heartbeat_result.get("requires_capabilities"):
+                    # Resolve a restarted Proxy or changed local capability contract
+                    # without making every regular heartbeat carry the full object.
+                    await client.heartbeat(runtime_instance_id, capabilities=capabilities)
                 fail = 0
             except Exception as e:
                 fail += 1

--- a/instance/pclient/proxy_client.py
+++ b/instance/pclient/proxy_client.py
@@ -62,7 +62,7 @@ class ProxyControlClient:
         instance_id: str,
         capability_fingerprint: Optional[str] = None,
         capabilities: Optional[InstanceCapability] = None,
-    ) -> None:
+    ) -> Dict[str, Any]:
         payload = {"instance_id": instance_id}
         if capability_fingerprint is not None:
             payload["capability_fingerprint"] = capability_fingerprint
@@ -70,6 +70,7 @@ class ProxyControlClient:
             payload["capabilities"] = capabilities.model_dump(mode="json")
         r = await self._client.post(f"{self.base_url}/v1/instance/heartbeat", json=payload)
         r.raise_for_status()
+        return r.json()
 
     async def unregister(self, instance_id: str) -> None:
         r = await self._client.post(f"{self.base_url}/v1/instance/unregister", json={"instance_id": instance_id})

--- a/instance/pclient/proxy_client.py
+++ b/instance/pclient/proxy_client.py
@@ -7,12 +7,15 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+from core.instance_capability import InstanceCapability
+
 
 @dataclass
 class RegisterResult:
     instance_id: str
     heartbeat_interval_s: int
     ttl_s: int
+    capability_fingerprint: Optional[str] = None
 
 
 class ProxyControlClient:
@@ -30,6 +33,8 @@ class ProxyControlClient:
         port: int,
         endpoints: Optional[List[str]] = None,
         meta: Optional[Dict[str, Any]] = None,
+        capabilities: Optional[InstanceCapability] = None,
+        capability_fingerprint: Optional[str] = None,
     ) -> RegisterResult:
         payload = {
             "instance_id": instance_id,
@@ -38,6 +43,10 @@ class ProxyControlClient:
             "endpoints": endpoints or ["chat/completions", "completions"],
             "meta": meta or {},
         }
+        if capabilities is not None:
+            payload["capabilities"] = capabilities.model_dump(mode="json")
+        if capability_fingerprint is not None:
+            payload["capability_fingerprint"] = capability_fingerprint
         r = await self._client.post(f"{self.base_url}/v1/instance/register", json=payload)
         r.raise_for_status()
         j = r.json()
@@ -45,10 +54,21 @@ class ProxyControlClient:
             instance_id=j["instance_id"],
             heartbeat_interval_s=int(j.get("heartbeat_interval_s", 10)),
             ttl_s=int(j.get("ttl_s", 30)),
+            capability_fingerprint=j.get("capability_fingerprint"),
         )
 
-    async def heartbeat(self, instance_id: str) -> None:
-        r = await self._client.post(f"{self.base_url}/v1/instance/heartbeat", json={"instance_id": instance_id})
+    async def heartbeat(
+        self,
+        instance_id: str,
+        capability_fingerprint: Optional[str] = None,
+        capabilities: Optional[InstanceCapability] = None,
+    ) -> None:
+        payload = {"instance_id": instance_id}
+        if capability_fingerprint is not None:
+            payload["capability_fingerprint"] = capability_fingerprint
+        if capabilities is not None:
+            payload["capabilities"] = capabilities.model_dump(mode="json")
+        r = await self._client.post(f"{self.base_url}/v1/instance/heartbeat", json=payload)
         r.raise_for_status()
 
     async def unregister(self, instance_id: str) -> None:

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -496,9 +496,18 @@ Common environment variables:
 
 The Proxy always recomputes the fingerprint and replaces any client-provided value;
 the registration response and `GET /v1/instance/list` expose the accepted value.
+A fresh registration replaces capability state, so re-registering an existing ID
+without `capabilities` clears capabilities and its fingerprint from the previous
+process. In contrast, heartbeat omission preserves registered capability state.
+
 Heartbeat requests may omit both fields, send only the fingerprint, or resend a
-changed capability object. Omission never erases stored capability data. Legacy
-registration, `meta`, and instance-ID-only heartbeat payloads remain valid.
+changed capability object. A matching fingerprint refreshes liveness. A mismatch,
+or a fingerprint received when the Proxy has no stored fingerprint, returns
+`ok: false`, `requires_capabilities: true`, the expected/reported values, and a
+`capability_fingerprint_mismatch` or `capability_fingerprint_unknown` error. Such a
+heartbeat does not refresh `last_seen_at` and does not overwrite capabilities; the
+Instance resolves it by sending the complete capability object. Legacy registration,
+`meta`, and instance-ID-only heartbeat payloads remain valid.
 
 The shared comparison utility returns `compatible`, `incompatible`, or `unknown`,
 plus both fingerprints and machine-readable mismatch entries. Missing legacy or

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -482,3 +482,25 @@ Common environment variables:
 - Repeated successful resource reports are intentionally quiet to avoid log flooding.
 - `unknown_instance` warnings usually mean a stale or external Instance process is still heartbeating to the Proxy control plane.
 - The Proxy UI is the preferred visual entry point for Proxy observability during demos and experiments.
+# Instance capability contract
+
+`POST /v1/instance/register` accepts optional `capabilities` and
+`capability_fingerprint` fields. For example:
+
+```json
+{"instance_id":"instance-1","host":"127.0.0.1","port":9001,
+ "capabilities":{"schema_version":"1","model":{"identifier":"model-a"},
+ "tokenizer":{"identifier":"model-a"},"kv_cache":{"layout":"paged","dtype":"fp16"},
+ "parallelism":{"tensor_parallel_size":1,"pipeline_parallel_size":1,"data_parallel_size":1}}}
+```
+
+The Proxy always recomputes the fingerprint and replaces any client-provided value;
+the registration response and `GET /v1/instance/list` expose the accepted value.
+Heartbeat requests may omit both fields, send only the fingerprint, or resend a
+changed capability object. Omission never erases stored capability data. Legacy
+registration, `meta`, and instance-ID-only heartbeat payloads remain valid.
+
+The shared comparison utility returns `compatible`, `incompatible`, or `unknown`,
+plus both fingerprints and machine-readable mismatch entries. Missing legacy or
+incomplete data is `unknown`; v0.1.10 records this status contract but does not use
+it to alter routing or cache placement.

--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -1,2 +1,11 @@
-from .proxy import proxy
+"""Public Proxy application, loaded lazily for lightweight resource tooling."""
+from importlib import import_module
+
+
+def __getattr__(name):
+    if name != "proxy":
+        raise AttributeError(name)
+    value = import_module(".proxy", __name__).proxy
+    globals()[name] = value
+    return value
 

--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -1,11 +1,2 @@
-"""Public Proxy application, loaded lazily for lightweight resource tooling."""
-from importlib import import_module
-
-
-def __getattr__(name):
-    if name != "proxy":
-        raise AttributeError(name)
-    value = import_module(".proxy", __name__).proxy
-    globals()[name] = value
-    return value
+from .proxy import proxy
 

--- a/proxy/resource/instance_pool.py
+++ b/proxy/resource/instance_pool.py
@@ -7,6 +7,8 @@ import threading
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from core.instance_capability import InstanceCapability, capability_fingerprint
+
 from proxy.strategy.least_load import LeastLoadStrategy
 
 
@@ -55,6 +57,8 @@ class InstanceInfo:
     tags: List[str] = field(default_factory=list)
     weight: float = 1.0
     meta: Dict[str, Any] = field(default_factory=dict)
+    capabilities: Optional[InstanceCapability] = None
+    capability_fingerprint: Optional[str] = None
 
     load: InstanceLoad = field(default_factory=InstanceLoad)
     resource: InstanceResource = field(default_factory=InstanceResource)
@@ -87,6 +91,7 @@ class InstancePool:
         tags: Optional[List[str]] = None,
         weight: float = 1.0,
         meta: Optional[Dict[str, Any]] = None,
+        capabilities: Optional[InstanceCapability] = None,
     ) -> InstanceInfo:
         now = int(time.time())
         with self._lock:
@@ -99,6 +104,9 @@ class InstancePool:
                 it.weight = float(weight)
                 if meta:
                     it.meta.update(meta)
+                if capabilities is not None:
+                    it.capabilities = capabilities
+                    it.capability_fingerprint = capability_fingerprint(capabilities)
                 if it.load.inflight is None:
                     it.load.inflight = 0
                 it.last_seen_at = now
@@ -112,6 +120,8 @@ class InstancePool:
                 tags=tags or [],
                 weight=float(weight),
                 meta=meta or {},
+                capabilities=capabilities,
+                capability_fingerprint=capability_fingerprint(capabilities) if capabilities is not None else None,
                 load=InstanceLoad(inflight=0),
                 registered_at=now,
                 last_seen_at=now,
@@ -125,6 +135,8 @@ class InstancePool:
         inflight: Optional[int] = None,
         qps_1m: Optional[float] = None,
         gpu_util: Optional[float] = None,
+        capabilities: Optional[InstanceCapability] = None,
+        capability_fingerprint_value: Optional[str] = None,
     ) -> bool:
         now = int(time.time())
         with self._lock:
@@ -138,6 +150,13 @@ class InstancePool:
                 it.load.qps_1m = float(qps_1m)
             if gpu_util is not None:
                 it.load.gpu_util = float(gpu_util)
+            if capabilities is not None:
+                it.capabilities = capabilities
+                it.capability_fingerprint = capability_fingerprint(capabilities)
+            elif capability_fingerprint_value is not None and it.capability_fingerprint is not None:
+                # A fingerprint-only heartbeat is an identity assertion, not new capability data.
+                # Keep the server-computed value authoritative.
+                pass
             return True
 
     def report_resource_snapshot(

--- a/proxy/resource/instance_pool.py
+++ b/proxy/resource/instance_pool.py
@@ -66,6 +66,28 @@ class InstanceInfo:
     last_seen_at: int = field(default_factory=lambda: int(time.time()))
 
 
+@dataclass(frozen=True)
+class HeartbeatResult:
+    """Describe whether a heartbeat refreshed liveness and capability state."""
+
+    ok: bool
+    error: Optional[str] = None
+    requires_capabilities: bool = False
+    expected_fingerprint: Optional[str] = None
+    reported_fingerprint: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {"ok": self.ok}
+        if self.error is not None:
+            result.update({
+                "error": self.error,
+                "requires_capabilities": self.requires_capabilities,
+                "expected_fingerprint": self.expected_fingerprint,
+                "reported_fingerprint": self.reported_fingerprint,
+            })
+        return result
+
+
 class InstancePool:
     """
     In-memory instance pool (TTL based).
@@ -104,9 +126,12 @@ class InstancePool:
                 it.weight = float(weight)
                 if meta:
                     it.meta.update(meta)
-                if capabilities is not None:
-                    it.capabilities = capabilities
-                    it.capability_fingerprint = capability_fingerprint(capabilities)
+                # Registration represents a new process/static-state declaration.
+                # Unlike heartbeat omission, missing capabilities clear old state.
+                it.capabilities = capabilities
+                it.capability_fingerprint = (
+                    capability_fingerprint(capabilities) if capabilities is not None else None
+                )
                 if it.load.inflight is None:
                     it.load.inflight = 0
                 it.last_seen_at = now
@@ -137,12 +162,27 @@ class InstancePool:
         gpu_util: Optional[float] = None,
         capabilities: Optional[InstanceCapability] = None,
         capability_fingerprint_value: Optional[str] = None,
-    ) -> bool:
+    ) -> HeartbeatResult:
         now = int(time.time())
         with self._lock:
             it = self._items.get(instance_id)
             if not it:
-                return False
+                return HeartbeatResult(ok=False)
+            if capabilities is None and capability_fingerprint_value is not None:
+                if it.capability_fingerprint != capability_fingerprint_value:
+                    # Do not refresh liveness until the Instance sends the complete
+                    # capability object and resolves the unknown/mismatched state.
+                    return HeartbeatResult(
+                        ok=False,
+                        error=(
+                            "capability_fingerprint_unknown"
+                            if it.capability_fingerprint is None
+                            else "capability_fingerprint_mismatch"
+                        ),
+                        requires_capabilities=True,
+                        expected_fingerprint=it.capability_fingerprint,
+                        reported_fingerprint=capability_fingerprint_value,
+                    )
             it.last_seen_at = now
             # Inflight is Proxy-maintained via begin_request/end_request.
             # Keep heartbeat load updates for non-lifecycle signals only.
@@ -153,11 +193,7 @@ class InstancePool:
             if capabilities is not None:
                 it.capabilities = capabilities
                 it.capability_fingerprint = capability_fingerprint(capabilities)
-            elif capability_fingerprint_value is not None and it.capability_fingerprint is not None:
-                # A fingerprint-only heartbeat is an identity assertion, not new capability data.
-                # Keep the server-computed value authoritative.
-                pass
-            return True
+            return HeartbeatResult(ok=True)
 
     def report_resource_snapshot(
         self,

--- a/proxy/resource/p_control_plane.py
+++ b/proxy/resource/p_control_plane.py
@@ -9,7 +9,9 @@ import time
 from typing import Any, Callable, Dict, List, Optional
 
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from core.instance_capability import InstanceCapability
 
 from .instance_pool import InstancePool
 
@@ -78,10 +80,12 @@ class InstanceRegisterReq(BaseModel):
     instance_id: Optional[str] = None
     host: str
     port: int
-    endpoints: List[str] = []
-    tags: List[str] = []
+    endpoints: List[str] = Field(default_factory=list)
+    tags: List[str] = Field(default_factory=list)
     weight: float = 1.0
-    meta: Dict[str, Any] = {}
+    meta: Dict[str, Any] = Field(default_factory=dict)
+    capabilities: Optional[InstanceCapability] = None
+    capability_fingerprint: Optional[str] = None
 
 
 class InstanceHeartbeatReq(BaseModel):
@@ -89,6 +93,8 @@ class InstanceHeartbeatReq(BaseModel):
     inflight: Optional[int] = None
     qps_1m: Optional[float] = None
     gpu_util: Optional[float] = None
+    capabilities: Optional[InstanceCapability] = None
+    capability_fingerprint: Optional[str] = None
 
 
 class InstanceUnregisterReq(BaseModel):
@@ -176,6 +182,7 @@ async def register(req: InstanceRegisterReq) -> Dict[str, Any]:
         tags=req.tags,
         weight=req.weight,
         meta=req.meta,
+        capabilities=req.capabilities,
     )
 
     logger.info(
@@ -189,6 +196,7 @@ async def register(req: InstanceRegisterReq) -> Dict[str, Any]:
         "instance_id": it.instance_id,
         "heartbeat_interval_s": hb,
         "ttl_s": pool.ttl_s,
+        "capability_fingerprint": it.capability_fingerprint,
     }
 
 
@@ -200,6 +208,8 @@ async def heartbeat(req: InstanceHeartbeatReq) -> Dict[str, Any]:
         inflight=req.inflight,
         qps_1m=req.qps_1m,
         gpu_util=req.gpu_util,
+        capabilities=req.capabilities,
+        capability_fingerprint_value=req.capability_fingerprint,
     )
     if not ok:
         logger.warning("[ProxyCP] heartbeat for unknown instance_id=%s", req.instance_id)
@@ -257,6 +267,8 @@ async def list_instances(include_dead: bool = False) -> List[Dict[str, Any]]:
             "tags": it.tags,
             "weight": it.weight,
             "meta": it.meta,
+            "capabilities": it.capabilities.model_dump(mode="json") if it.capabilities else None,
+            "capability_fingerprint": it.capability_fingerprint,
             "registered_at": it.registered_at,
             "last_seen_at": it.last_seen_at,
             "load": {

--- a/proxy/resource/p_control_plane.py
+++ b/proxy/resource/p_control_plane.py
@@ -203,7 +203,7 @@ async def register(req: InstanceRegisterReq) -> Dict[str, Any]:
 @_control_plane.post("/v1/instance/heartbeat")
 async def heartbeat(req: InstanceHeartbeatReq) -> Dict[str, Any]:
     pool = get_pool()
-    ok = pool.heartbeat(
+    result = pool.heartbeat(
         instance_id=req.instance_id,
         inflight=req.inflight,
         qps_1m=req.qps_1m,
@@ -211,10 +211,14 @@ async def heartbeat(req: InstanceHeartbeatReq) -> Dict[str, Any]:
         capabilities=req.capabilities,
         capability_fingerprint_value=req.capability_fingerprint,
     )
-    if not ok:
-        logger.warning("[ProxyCP] heartbeat for unknown instance_id=%s", req.instance_id)
+    if not result.ok:
+        logger.warning(
+            "[ProxyCP] heartbeat rejected: instance_id=%s error=%s",
+            req.instance_id,
+            result.error,
+        )
 
-    return {"ok": ok}
+    return result.to_dict()
 
 
 @_control_plane.post("/v1/instance/resource_snapshot")

--- a/test/test_instance_capability.py
+++ b/test/test_instance_capability.py
@@ -1,0 +1,123 @@
+import json
+
+import pytest
+
+from core.instance_capability import InstanceCapability, capability_fingerprint, compare_capabilities
+from instance import capability_builder
+
+
+def complete_capability(**changes):
+    data = {
+        "schema_version": "1",
+        "model": {"identifier": "model-a", "revision": "r1"},
+        "tokenizer": {"identifier": "tokenizer-a", "revision": "r1"},
+        "adapters": [
+            {"identifier": "adapter-a", "revision": "1", "configuration": {"rank": 8}},
+            {"identifier": "adapter-b", "revision": "2", "configuration_hash": "sha256:a"},
+        ],
+        "kv_cache": {"layout": "paged", "schema_version": "1", "dtype": "fp16", "block_size": 16,
+                     "layout_parameters": {"heads": 8}},
+        "parallelism": {"tensor_parallel_size": 2, "pipeline_parallel_size": 1, "data_parallel_size": 1},
+        "runtime": {"vllm_version": "1.0", "lmcache_version": "2.0",
+                    "supported_cache_features": ["lookup", "transfer"]},
+    }
+    for path, value in changes.items():
+        target = data
+        parts = path.split("__")
+        for part in parts[:-1]:
+            target = target[part]
+        target[parts[-1]] = value
+    return InstanceCapability.model_validate(data)
+
+
+def test_fingerprint_is_canonical_and_feature_order_is_set_like():
+    left = complete_capability()
+    raw = json.loads(left.model_dump_json())
+    raw = {key: raw[key] for key in reversed(raw)}
+    raw["runtime"]["supported_cache_features"] = ["transfer", "lookup", "lookup"]
+    assert capability_fingerprint(left) == capability_fingerprint(raw)
+
+
+@pytest.mark.parametrize("path,value", [
+    ("model__identifier", "model-b"), ("tokenizer__identifier", "tokenizer-b"),
+    ("kv_cache__layout", "contiguous"), ("kv_cache__dtype", "bf16"),
+    ("parallelism__tensor_parallel_size", 4), ("parallelism__pipeline_parallel_size", 2),
+    ("parallelism__data_parallel_size", 2),
+])
+def test_compatibility_fields_change_fingerprint_and_report_path(path, value):
+    left, right = complete_capability(), complete_capability(**{path: value})
+    assert capability_fingerprint(left) != capability_fingerprint(right)
+    result = compare_capabilities(left, right)
+    assert result.status == "incompatible"
+    assert result.compatible is False
+    assert path.replace("__", ".") in {item.field for item in result.mismatches}
+
+
+def test_adapter_stack_order_is_semantically_meaningful():
+    left = complete_capability()
+    raw = left.model_dump()
+    raw["adapters"].reverse()
+    assert capability_fingerprint(left) != capability_fingerprint(raw)
+
+
+def test_transient_unmodelled_data_is_rejected_not_fingerprinted():
+    raw = complete_capability().model_dump()
+    raw["host"] = "example.invalid"
+    with pytest.raises(ValueError):
+        capability_fingerprint(raw)
+
+
+def test_matching_complete_capabilities_are_compatible():
+    result = compare_capabilities(complete_capability(), complete_capability())
+    assert result.status == "compatible"
+    assert result.compatible and result.mismatches == []
+    assert result.left_fingerprint == result.right_fingerprint
+
+
+def test_multiple_mismatches_are_all_machine_readable():
+    result = compare_capabilities(
+        complete_capability(), complete_capability(model__identifier="b", kv_cache__dtype="bf16")
+    )
+    assert {item.field for item in result.mismatches} >= {"model.identifier", "kv_cache.dtype"}
+    assert all(item.reason == "value_mismatch" for item in result.mismatches)
+
+
+def test_missing_legacy_or_incomplete_capabilities_are_unknown():
+    assert compare_capabilities(None, complete_capability()).status == "unknown"
+    result = compare_capabilities(InstanceCapability(), InstanceCapability())
+    assert result.status == "unknown"
+    assert not result.compatible
+
+
+def test_builder_defaults_and_environment_overrides(monkeypatch):
+    monkeypatch.setenv("INSTANCE_MODEL_ID", "env-model")
+    monkeypatch.setenv("INSTANCE_MODEL_REVISION", "rev")
+    monkeypatch.setenv("INSTANCE_KV_BLOCK_SIZE", "32")
+    monkeypatch.setenv("INSTANCE_TENSOR_PARALLEL_SIZE", "4")
+    monkeypatch.setenv("INSTANCE_CACHE_FEATURES", "transfer, lookup")
+    monkeypatch.setenv("INSTANCE_VLLM_VERSION", "override")
+    monkeypatch.setenv("INSTANCE_ADAPTERS_JSON", '[{"identifier":"lora","configuration":{"rank":8}}]')
+    capability = capability_builder.build_instance_capability()
+    assert capability.model.identifier == capability.tokenizer.identifier == "env-model"
+    assert capability.kv_cache.block_size == 32
+    assert capability.parallelism.tensor_parallel_size == 4
+    assert capability.runtime.vllm_version == "override"
+    assert capability.adapters[0].identifier == "lora"
+
+
+def test_builder_tolerates_missing_packages(monkeypatch):
+    monkeypatch.delenv("INSTANCE_VLLM_VERSION", raising=False)
+    monkeypatch.delenv("INSTANCE_LMCACHE_VERSION", raising=False)
+    def missing(_name):
+        raise capability_builder.metadata.PackageNotFoundError
+    monkeypatch.setattr(capability_builder.metadata, "version", missing)
+    capability = capability_builder.build_instance_capability()
+    assert capability.runtime.vllm_version is None
+    assert capability.runtime.lmcache_version is None
+
+
+@pytest.mark.parametrize("raw", ["not-json", "{}"])
+def test_invalid_adapter_json_has_predictable_error(monkeypatch, raw):
+    monkeypatch.setenv("INSTANCE_ADAPTERS_JSON", raw)
+    with pytest.raises(ValueError, match="INSTANCE_ADAPTERS_JSON"):
+        capability_builder.build_instance_capability()

--- a/test/test_instance_capability_registration.py
+++ b/test/test_instance_capability_registration.py
@@ -1,0 +1,63 @@
+from fastapi.testclient import TestClient
+
+from core.instance_capability import capability_fingerprint
+from proxy.resource.instance_pool import InstancePool
+from proxy.resource.p_control_plane import _control_plane, set_pool
+
+
+def payload():
+    return {
+        "schema_version": "1", "model": {"identifier": "m"},
+        "tokenizer": {"identifier": "m"}, "kv_cache": {"layout": "paged", "dtype": "fp16"},
+        "parallelism": {"tensor_parallel_size": 1, "pipeline_parallel_size": 1, "data_parallel_size": 1},
+    }
+
+
+def client():
+    set_pool(InstancePool(ttl_s=30))
+    return TestClient(_control_plane)
+
+
+def test_legacy_registration_and_heartbeat_remain_accepted():
+    with client() as api:
+        response = api.post("/v1/instance/register", json={"instance_id": "legacy", "host": "h", "port": 1,
+                                                               "meta": {"old": True}})
+        assert response.status_code == 200
+        assert response.json()["capability_fingerprint"] is None
+        assert api.post("/v1/instance/heartbeat", json={"instance_id": "legacy"}).json() == {"ok": True}
+
+
+def test_registration_recomputes_fingerprint_and_list_exposes_contract():
+    capabilities = payload()
+    with client() as api:
+        response = api.post("/v1/instance/register", json={
+            "instance_id": "new", "host": "h", "port": 2, "capabilities": capabilities,
+            "capability_fingerprint": "sha256:incorrect",
+        })
+        expected = capability_fingerprint(capabilities)
+        assert response.status_code == 200
+        assert response.json()["capability_fingerprint"] == expected
+        item = api.get("/v1/instance/list").json()[0]
+        assert item["capabilities"]["model"]["identifier"] == "m"
+        assert item["capability_fingerprint"] == expected
+
+
+def test_heartbeat_omission_preserves_and_changed_object_updates_capability():
+    capabilities = payload()
+    with client() as api:
+        api.post("/v1/instance/register", json={"instance_id": "i", "host": "h", "port": 2,
+                                                "capabilities": capabilities})
+        old = api.get("/v1/instance/list").json()[0]["capability_fingerprint"]
+        api.post("/v1/instance/heartbeat", json={"instance_id": "i"})
+        assert api.get("/v1/instance/list").json()[0]["capability_fingerprint"] == old
+        capabilities["kv_cache"]["dtype"] = "bf16"
+        assert api.post("/v1/instance/heartbeat", json={"instance_id": "i", "capabilities": capabilities}).json()["ok"]
+        assert api.get("/v1/instance/list").json()[0]["capability_fingerprint"] == capability_fingerprint(capabilities)
+
+
+def test_malformed_capability_returns_structured_validation_error():
+    with client() as api:
+        response = api.post("/v1/instance/register", json={"host": "h", "port": 2,
+                                                           "capabilities": {"kv_cache": {"block_size": -1}}})
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["loc"][-1] == "block_size"

--- a/test/test_instance_capability_registration.py
+++ b/test/test_instance_capability_registration.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 from core.instance_capability import capability_fingerprint
 from proxy.resource.instance_pool import InstancePool
-from proxy.resource.p_control_plane import _control_plane, set_pool
+from proxy.resource.p_control_plane import _control_plane, get_pool, set_pool
 
 
 def payload():
@@ -25,6 +25,20 @@ def test_legacy_registration_and_heartbeat_remain_accepted():
         assert response.status_code == 200
         assert response.json()["capability_fingerprint"] is None
         assert api.post("/v1/instance/heartbeat", json={"instance_id": "legacy"}).json() == {"ok": True}
+
+
+def test_fresh_legacy_registration_clears_previous_capabilities():
+    with client() as api:
+        api.post("/v1/instance/register", json={
+            "instance_id": "reused", "host": "old", "port": 1, "capabilities": payload(),
+        })
+        response = api.post("/v1/instance/register", json={
+            "instance_id": "reused", "host": "new", "port": 2,
+        })
+        assert response.json()["capability_fingerprint"] is None
+        item = api.get("/v1/instance/list").json()[0]
+        assert item["capabilities"] is None
+        assert item["capability_fingerprint"] is None
 
 
 def test_registration_recomputes_fingerprint_and_list_exposes_contract():
@@ -53,6 +67,57 @@ def test_heartbeat_omission_preserves_and_changed_object_updates_capability():
         capabilities["kv_cache"]["dtype"] = "bf16"
         assert api.post("/v1/instance/heartbeat", json={"instance_id": "i", "capabilities": capabilities}).json()["ok"]
         assert api.get("/v1/instance/list").json()[0]["capability_fingerprint"] == capability_fingerprint(capabilities)
+
+
+def test_fingerprint_only_heartbeat_matches_registered_capability():
+    capabilities = payload()
+    with client() as api:
+        api.post("/v1/instance/register", json={
+            "instance_id": "i", "host": "h", "port": 2, "capabilities": capabilities,
+        })
+        response = api.post("/v1/instance/heartbeat", json={
+            "instance_id": "i", "capability_fingerprint": capability_fingerprint(capabilities),
+        })
+        assert response.json() == {"ok": True}
+
+
+def test_fingerprint_mismatch_does_not_refresh_liveness_and_full_object_resolves_it():
+    capabilities = payload()
+    with client() as api:
+        api.post("/v1/instance/register", json={
+            "instance_id": "i", "host": "h", "port": 2, "capabilities": capabilities,
+        })
+        pool = get_pool()
+        item = pool.list(include_dead=True)[0]
+        item.last_seen_at = 100
+        response = api.post("/v1/instance/heartbeat", json={
+            "instance_id": "i", "capability_fingerprint": "sha256:different",
+        })
+        assert response.json() == {
+            "ok": False, "error": "capability_fingerprint_mismatch", "requires_capabilities": True,
+            "expected_fingerprint": capability_fingerprint(capabilities),
+            "reported_fingerprint": "sha256:different",
+        }
+        assert item.last_seen_at == 100
+        assert item.capabilities.model_dump()["kv_cache"]["dtype"] == "fp16"
+        capabilities["kv_cache"]["dtype"] = "bf16"
+        assert api.post("/v1/instance/heartbeat", json={
+            "instance_id": "i", "capabilities": capabilities,
+        }).json() == {"ok": True}
+        assert item.capability_fingerprint == capability_fingerprint(capabilities)
+        assert item.last_seen_at > 100
+
+
+def test_fingerprint_only_heartbeat_without_stored_capability_requests_full_object():
+    with client() as api:
+        api.post("/v1/instance/register", json={"instance_id": "legacy", "host": "h", "port": 1})
+        response = api.post("/v1/instance/heartbeat", json={
+            "instance_id": "legacy", "capability_fingerprint": "sha256:reported",
+        })
+        assert response.json() == {
+            "ok": False, "error": "capability_fingerprint_unknown", "requires_capabilities": True,
+            "expected_fingerprint": None, "reported_fingerprint": "sha256:reported",
+        }
 
 
 def test_malformed_capability_returns_structured_validation_error():


### PR DESCRIPTION
### Motivation
- Establish a stable, typed instance capability contract and deterministic fingerprinting to enable future KVCache artifact reuse and compatibility checks without changing existing routing or injection behavior.
- Provide machine-readable compatibility results to make mismatch reasons observable for research-driven policy decisions while preserving legacy registration and heartbeat semantics.
- Keep instance startup and tests runnable in environments without vLLM/LMCache installed and avoid loading models during fingerprint construction.

### Description
- Add a shared Pydantic v2 capability schema and deterministic canonicalization/fingerprinting in `core/instance_capability.py`, including `capability_fingerprint()` and `compare_capabilities()` that returns structured `compatible`/`incompatible`/`unknown` results with machine-readable mismatches.
- Add `instance/capability_builder.py` to build an `InstanceCapability` from environment/config/package metadata without importing vLLM/LMCache or loading models, honoring precedence `env -> config -> detected -> null`.
- Wire capabilities into startup, registration, and heartbeat: Instance now builds capabilities and sends them on registration and sends the local fingerprint on normal heartbeats; Proxy recomputes and stores server-authoritative fingerprint and accepts optional capability-bearing heartbeats. Changes touch `instance/instance_api.py`, `instance/pclient/proxy_client.py`, `proxy/resource/p_control_plane.py`, and `proxy/resource/instance_pool.py`.
- Preserve backwards compatibility by keeping `meta`, accepting legacy registration and instance-ID-only heartbeats, and not erasing stored capability data when heartbeats omit capability fields.
- Add focused unit tests `test/test_instance_capability.py` and `test/test_instance_capability_registration.py`, document behavior in `instance/README.md` and `proxy/README.md`, and add small test-time/import helpers and lazy core/instance/proxy exports to avoid importing heavy optional dependencies during test collection.

### Testing
- `python -m compileall core instance proxy` — passed successfully.
- `pytest -q test/test_instance_capability.py` — 17 passed (fingerprinting and compatibility tests).
- `pytest -q proxy/resource/test_instance_pool_gpu.py` — 1 passed (existing instance-pool behavior unaffected).
- `pytest -q test/test_instance_capability_registration.py` — collection/execution was environment-limited because `FastAPI`/related packages were not available in the execution environment (dependency installation was attempted but package-index access was rejected), so this API-level test could not be exercised in this run.
- Full `pytest -q` could not complete in this environment due to unavailable optional runtime dependencies and a few repository tests that rely on local demo files; these are unrelated to the changes and are environment-dependent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6448a726608320a7aa39d5562a815f)