### PR TITLE
docs: align capability validation and package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ CacheRoute addresses this problem by using dedicated servers to store KVCache bl
 | ⚙️ **Compute-network-aware knowledge injection** | CacheRoute dynamically chooses between text recomputation and KVCache reuse. It predicts task cost at the Proxy and selects the injection strategy based on current task queues, compute load, and network load. |
 | 🧭 **Knowledge-oriented cross-system routing** | CacheRoute parses the knowledge requirement before resource-pool scheduling. The Scheduler jointly considers knowledge availability, system load, and topology information, and routes requests to the LLM system that can serve the required knowledge more efficiently. |
 | 🗂️ **KDN-based KV cache management** | CacheRoute follows the Knowledge Delivery Network concept and uses dedicated KDN servers to register, store, query, and inject KV cache blocks for reusable knowledge. |
+| 🔐 **Compatibility-aware Instance identity** | Instances report deterministic capability fingerprints for model, tokenizer, adapter stack, KV-cache layout/dtype, parallel configuration, and relevant vLLM/LMCache runtime versions. The Proxy recomputes and exposes the accepted identity contract. |
 | 📊 **Proxy browser UI and Instance resource dashboard** | CacheRoute provides a browser-based Proxy observability dashboard and an optional Instance resource dashboard for control-plane state, Instance liveness, resource snapshots, topology information, and short-term trends. |
 
 ---
@@ -78,8 +79,8 @@ CacheRoute separates global routing, local injection decisions, and KV cache man
 </p>
 
 - **Scheduler:** performs global resource-pool selection and knowledge-oriented task routing.
-- **Proxy:** manages local task queues, selects the knowledge-injection strategy, and exposes the main Proxy browser UI.
-- **Instance:** connects CacheRoute to vLLM + LMCache and handles execution signaling.
+- **Proxy:** manages local task queues, selects the knowledge-injection strategy, validates Instance capability identity, and exposes the main Proxy browser UI.
+- **Instance:** connects CacheRoute to vLLM + LMCache, reports a deterministic capability identity, and handles execution signaling.
 - **KDN Server:** stores reusable knowledge and injects KVCache blocks when needed.
 - **Resource Agent/Dashboard:** optionally observes local Instance resource snapshots for validation and future control-plane integration.
 
@@ -116,6 +117,12 @@ The URLs above assume a single-machine deployment with loopback addresses. Conta
 6. Instance resource snapshots can flow through the Proxy control plane. The Proxy aggregates a compact `pool_resource` snapshot and reports it to the Scheduler through registration and heartbeat payloads.
 7. The optional Proxy UI and Instance Resource Dashboard visualize control-plane and resource state for debugging and validation.
 
+### Instance capability identity
+
+At startup, each Instance builds a typed capability description and a deterministic `sha256:` fingerprint without loading a model or contacting an external service. The identity covers model and tokenizer revisions, adapter configuration, KV-cache layout and dtype, parallel configuration, and available vLLM/LMCache runtime information.
+
+The Instance sends the complete capability object during registration and uses lightweight fingerprint-only heartbeats afterward. The Proxy recomputes the server-authoritative fingerprint and exposes the accepted contract through `GET /v1/instance/list`. See [`instance/README.md`](instance/README.md) for capability construction and environment variables, and [`proxy/README.md`](proxy/README.md) for registration, mismatch, and recovery semantics.
+
 ---
 
 ## Requirements
@@ -139,6 +146,8 @@ Install CacheRoute's application dependencies with:
 python3 -m pip install -r requirements.txt
 python3 -m pip check
 ```
+
+`requirements.txt` is the dependency source of truth for the complete CacheRoute application and development environment. `pyproject.toml` provides package metadata and a deliberately smaller install surface; installing the project package alone does not replace the complete requirements installation.
 
 `requirements.txt` intentionally does not pin PyTorch, vLLM, or LMCache. These packages belong to the serving image and must remain compatible with its CUDA environment.
 
@@ -609,6 +618,7 @@ CacheRoute is under active development. The current release supports:
 - Proxy selection based on topology, load safety window, and knowledge history.
 - Proxy-side dynamic injection strategy selection.
 - KDN-based text registration and KVCache registration.
+- Deterministic Instance capability identity and compatibility-aware registration.
 - Proxy browser UI for control-plane, topology, Instance liveness, and resource-snapshot observability.
 - Optional Instance resource snapshots through a Rust agent and dashboard.
 - Debugging APIs such as `/debug/status` and `/debug/strategy`.
@@ -628,6 +638,7 @@ curl -s http://127.0.0.1:7001/debug/strategy
 - [x] Proxy-side dynamic injection strategy selection
 - [x] KDN-based text and KVCache registration
 - [x] OpenAI-compatible request forwarding
+- [x] Compatibility-aware Instance capability identity
 - [x] Proxy browser observability UI
 - [x] Optional Instance resource dashboard
 - [ ] Scheduler browser UI
@@ -645,10 +656,10 @@ curl -s http://127.0.0.1:7001/debug/strategy
 |---|---|
 | [`core/README.md`](core/README.md) | Shared configuration, request model, and multi-machine deployment settings. |
 | [`scheduler/README.md`](scheduler/README.md) | Global routing, KDN / Proxy pool management, and Scheduler control plane. |
-| [`proxy/README.md`](proxy/README.md) | Local Instance pool, prepare / ready queues, injection strategy, and Proxy resource APIs. |
-| [`instance/README.md`](instance/README.md) | Instance service and control planes, KVCache signaling, resource monitoring, and TTFT predictor. |
+| [`proxy/README.md`](proxy/README.md) | Local Instance pool, capability-aware registration, heartbeat recovery, prepare / ready queues, injection strategy, and Proxy resource APIs. |
+| [`instance/README.md`](instance/README.md) | Instance service and control planes, capability construction, KVCache signaling, resource monitoring, and TTFT predictor. |
 | [`kdn_server/README.md`](kdn_server/README.md) | KDN service, knowledge registration, KVCache build, and injection utilities. |
 | [`client/README.md`](client/README.md) | Client CLI, OpenAI-compatible request examples, and workload tools. |
 | [`env/README.md`](env/README.md) | Docker environment setup and vLLM + LMCache installation. |
-| [`test/README.md`](test/README.md) | Demo scripts, smoke-validation entry points, and local test helpers. |
+| [`test/README.md`](test/README.md) | Demo scripts, focused capability validation, smoke-test entry points, and local test helpers. |
 | [`doc/blog/README.md`](doc/blog/README.md) | Engineering changelog and milestone notes. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
-
 [project]
 name = "cacheroute"
-version = "0.1.8"
+version = "0.1.9"
 description = "Compute-network-aware LLM scheduling for flexible KV cache reuse across vLLM and LMCache systems."
 authors = [
   { name = "xxx", email = "xxx" }
@@ -10,6 +9,10 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 
+# This is the lightweight Python package install surface. Install
+# requirements.txt for the complete CacheRoute application and development
+# environment; serving-image packages such as PyTorch, vLLM, and LMCache remain
+# managed by the CUDA-compatible runtime image.
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn",
@@ -18,7 +21,6 @@ dependencies = [
     "pydantic>=2.6.0",
     "pyyaml>=6.0.0",
     "jinja2>=3.1.0",
-
 ]
 
 [build-system]
@@ -39,4 +41,3 @@ dev = [
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = ["tests*", "docs*", "examples*"]
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-# CacheRoute application dependencies.
+# CacheRoute application and development dependencies.
+#
+# This file is the dependency source of truth for a complete CacheRoute
+# application/development environment. pyproject.toml intentionally exposes a
+# smaller package install surface and is not a replacement for this file.
 #
 # PyTorch, vLLM, and LMCache belong to the serving environment and are
 # intentionally not pinned here. Installing a different torch build over an

--- a/test/README.md
+++ b/test/README.md
@@ -2,6 +2,13 @@
 
 `test/` contains local entrypoints, smoke scripts, and historical utility tests for CacheRoute development. The main `demo_*.py` entrypoints add the repository root to Python's module search path, so the documented commands can be launched directly from the `test` directory without manually setting `PYTHONPATH`.
 
+Install the complete application and development dependency set from the repository root before running the commands in this document:
+
+```bash
+python3 -m pip install -r requirements.txt
+python3 -m pip check
+```
+
 If an older checkout reports `ModuleNotFoundError: No module named 'core'`, update the checkout or temporarily run:
 
 ```bash
@@ -26,7 +33,7 @@ The default single-machine demo ports are:
 | Component | Default URL | Started by | Notes |
 |---|---|---|---|
 | Proxy UI | `http://127.0.0.1:8202` | `demo_proxy.py` | Enabled by default. Use `--no-proxy-ui` to disable. |
-| Client UI | `http://127.0.0.1:7071/ui/client` | `demo_client.py --with-ui` | Sends OpenAI-compatible requests to Scheduler. |
+| Client UI | `http://127.0.0.1:7071` | `demo_client.py --with-ui` | Sends OpenAI-compatible requests to Scheduler. |
 | Instance Resource Dashboard | `http://127.0.0.1:9202` | `instance/resource_dashboard/dashboard_server.py` | Browser fallback for the Rust Resource Agent. |
 | Scheduler UI | TBD | TBD | Planned. |
 | KDN Server UI | TBD | TBD | Planned. |
@@ -53,10 +60,126 @@ The default single-machine demo ports are:
 | `test.py` | Legacy scratch/test entrypoint. Inspect before use. |
 | `test_kb_kid.py` | Knowledge-base / knowledge-id validation. |
 | `test_injector_reuse.py` | Injector reuse validation. |
-| `test_kv_injector_reuse.py` | KVCache injector reuse validation. |
+| `test_kv_injector_reuse.py` | External-service KVCache reuse script. It requires a reachable vLLM-compatible endpoint at `127.0.0.1:8000` and is not an isolated CPU-only unit test. |
 | `Injection_method_comparison.py` | Compares injection methods for local experiments. |
 | `Prefill_calculation.py` | Prefill-time calculation helper. |
 | `quick_start_docker.sh` | Convenience script for container-oriented startup. |
+
+## Focused Instance capability validation
+
+The Instance capability contract covers deterministic fingerprints, structured compatibility results, capability-aware registration, and heartbeat recovery while preserving legacy payloads.
+
+Run the focused CPU-only suite from the repository root:
+
+```bash
+python3 -m compileall core instance proxy
+
+pytest -q test/test_instance_capability.py
+pytest -q test/test_instance_capability_registration.py
+pytest -q proxy/resource/test_instance_pool_gpu.py
+
+pytest -q \
+  test/test_instance_capability.py \
+  test/test_instance_capability_registration.py \
+  proxy/resource/test_instance_pool_gpu.py
+```
+
+The focused tests verify:
+
+- canonical and deterministic `sha256:` capability fingerprints;
+- model, tokenizer, KV layout, dtype, and parallelism mismatch reporting;
+- legacy registration and instance-ID-only heartbeats;
+- server-authoritative fingerprint calculation;
+- fresh registration replacement versus heartbeat omission preservation;
+- fingerprint-only heartbeat match, mismatch, and full-capability recovery;
+- InstancePool resource behavior.
+
+Validate the previously public imports with:
+
+```bash
+python3 - <<'PY'
+from core import (
+    MLAmodel,
+    Request,
+    Prompt,
+    Service,
+    Task,
+    TokenizerRegistry,
+    forward_request,
+)
+from instance import (
+    instance,
+    mock_chat_stream,
+    mock_chat_completion,
+    mock_text_completion,
+)
+from proxy import proxy
+
+assert all(
+    item is not None
+    for item in (
+        MLAmodel,
+        Request,
+        Prompt,
+        Service,
+        Task,
+        TokenizerRegistry,
+        forward_request,
+        instance,
+        mock_chat_stream,
+        mock_chat_completion,
+        mock_text_completion,
+        proxy,
+    )
+)
+print("public import compatibility: passed")
+PY
+```
+
+For a registration smoke test, start `demo_proxy.py` and launch `demo_instance.py` with explicit capability values:
+
+```bash
+INSTANCE_MODEL_ID=test-model \
+INSTANCE_TOKENIZER_ID=test-tokenizer \
+INSTANCE_KV_LAYOUT=paged \
+INSTANCE_KV_SCHEMA_VERSION=1 \
+INSTANCE_KV_DTYPE=fp16 \
+INSTANCE_KV_BLOCK_SIZE=16 \
+INSTANCE_TENSOR_PARALLEL_SIZE=1 \
+INSTANCE_PIPELINE_PARALLEL_SIZE=1 \
+INSTANCE_DATA_PARALLEL_SIZE=1 \
+python3 test/demo_instance.py \
+  --host 127.0.0.1 \
+  --port 9001 \
+  --proxy-cp-url http://127.0.0.1:8002 \
+  --no-resource-monitor
+```
+
+Then inspect the accepted capability object and server-computed fingerprint:
+
+```bash
+curl -sS \
+  "http://127.0.0.1:8002/v1/instance/list?include_dead=true" \
+  | python3 -m json.tool
+```
+
+The result should expose the model, tokenizer, KV layout/dtype/block size, parallelism values, detected runtime versions when available, and a `capability_fingerprint` beginning with `sha256:`.
+
+### External-service collection note
+
+`test/test_kv_injector_reuse.py` performs requests to `http://127.0.0.1:8000/v1/chat/completions` at module import time. Generic `pytest -q` collection can therefore fail with `ConnectionError` when the external vLLM-compatible endpoint is not running. This is an environment-dependent historical integration script rather than a failure of the capability unit tests.
+
+For a CPU-only local run that does not provide the external endpoint, exclude that script explicitly:
+
+```bash
+pytest -q --ignore=test/test_kv_injector_reuse.py
+```
+
+Run the script directly only after the endpoint and its configured model are ready:
+
+```bash
+python3 test/test_kv_injector_reuse.py
+```
 
 ## Minimal Proxy + Instance resource-monitor demo
 


### PR DESCRIPTION
## Summary

Synchronize developer-facing capability documentation, validation instructions, dependency-source guidance, and Python package metadata after the Instance capability fingerprint work landed.

## Changes

- surface compatibility-aware Instance identity in the root `README.md`, including architecture, current-status, roadmap, and component-documentation references;
- align the `pyproject.toml` package version with the current v0.1.9 release baseline;
- clarify that `requirements.txt` is the dependency source of truth for the complete CacheRoute application and development environment;
- keep `pyproject.toml` as a lightweight package install surface without changing its dependency set;
- add focused Instance capability fingerprint, compatibility, registration, heartbeat, and public-import validation commands to `test/README.md`;
- add a Proxy + Instance capability-registration smoke-test procedure;
- document that `test/test_kv_injector_reuse.py` requires an external vLLM-compatible endpoint and may fail generic pytest collection when that endpoint is unavailable.

## Developer Impact

Developers can now discover the Instance capability contract from the project entry point, reproduce the focused v0.1.10-1 validation workflow, and distinguish package metadata from the complete dependency installation flow.

## Scope

This pull request changes documentation and package metadata only. It does not change runtime behavior, routing, cache placement, dependency versions, or the public v0.1.9 release badge.

## Validation

- `pyproject.toml` parsed successfully with Python `tomllib`.
- Branch comparison confirms changes are limited to `README.md`, `pyproject.toml`, `requirements.txt`, and `test/README.md`.
- The documented focused test and smoke-test commands match the validation performed for the merged capability implementation.