### PR TITLE
observability: propagate Scheduler trace context and instrument Proxy stages

### DIFF
--- a/doc/architecture/observability-v1.md
+++ b/doc/architecture/observability-v1.md
@@ -49,8 +49,40 @@ copied. Ambiguous or overwritten values are labeled `legacy_projected`, never
 upgraded to actual observations. The current `cacheroute_meta` has no
 `request_id`, and this foundation does not add one.
 
-Phase 4A does not instrument services, propagate trace context across
-processes, change requests or responses, export telemetry, perform I/O, or
-integrate with OpenTelemetry, Gateway implementations, LMCache, or vLLM.
-Later focused work may add propagation and adapters after their wire and
-failure semantics are reviewed.
+## Scheduler-to-Proxy propagation
+
+The Scheduler now creates the internal context and overwrites the complete
+reserved header set: `scheduler-request-id`, `x-cacheroute-trace-version`,
+`x-cacheroute-trace-id`, `x-cacheroute-runtime-profile`,
+`x-cacheroute-trace-sampled`, and `x-cacheroute-trace-created-at`. The request
+ID allocated by the Scheduler remains authoritative. Client values using these
+names are never trusted; Authorization forwarding and the serialized payload
+remain unchanged. Propagation stops at the Proxy and no trace header or model
+is sent to an Instance or returned to a client.
+
+Scheduler and Proxy each resolve `CACHEROUTE_RUNTIME_PROFILE` once at startup,
+with `legacy` as the compatibility default. `auto` is startup-only. A missing,
+malformed, stale, request-ID-mismatched, or profile-mismatched context causes a
+Proxy-local context to be created and never rejects an otherwise valid request.
+Profile metadata does not select runtime behavior.
+
+`CACHEROUTE_TRACE_SAMPLE_RATE` defaults to `0.0`. Invalid configuration fails
+closed to that value. Rates of zero and one disable or enable collection for
+every request; intermediate decisions are deterministically derived from the
+canonical trace ID. An accepted context retains the Scheduler decision.
+
+## Proxy-observed stages
+
+The Proxy prepare queue interval starts immediately before `prepare_q.put` and
+finishes at dequeue. The ready queue interval starts immediately before the
+current ready-queue insertion and finishes after the dispatch-turn wait,
+immediately before forwarding. Completion spans downstream handling. For
+streams, first-token spans forwarding to the first non-empty chunk and decode
+spans from that chunk until stream end. Non-streaming requests explicitly skip
+first-token and decode; empty streams explicitly fail first-token and skip
+decode. These are **Proxy-observed transport boundaries**, not authoritative
+vLLM execution, prefill, decode, Gateway, or LMCache timings.
+
+Collection remains process-local and immutable. The Legacy trace mapping and
+client metadata are unchanged and are not copied into `RequestTrace`. There is
+no client export, external exporter, registry, debug endpoint, or persistence.

--- a/doc/architecture/observability-v1.md
+++ b/doc/architecture/observability-v1.md
@@ -60,11 +60,7 @@ names are never trusted; Authorization forwarding and the serialized payload
 remain unchanged. Propagation stops at the Proxy and no trace header or model
 is sent to an Instance or returned to a client.
 
-Scheduler and Proxy each resolve `CACHEROUTE_RUNTIME_PROFILE` once at startup,
-with `legacy` as the compatibility default. `auto` is startup-only. A missing,
-malformed, stale, request-ID-mismatched, or profile-mismatched context causes a
-Proxy-local context to be created and never rejects an otherwise valid request.
-Profile metadata does not select runtime behavior.
+Scheduler and Proxy each resolve `CACHEROUTE_RUNTIME_PROFILE` through an explicit lifespan startup helper, with `legacy` as the compatibility default. Because the current services do not have an implemented production v1 data path, `auto` resolves with `v1_available=False` and is stored as `legacy`; explicit `legacy`, `test/mock`, and `v1` remain valid metadata values, but no stored or propagated context can remain `auto`. A missing, malformed, stale, request-ID-mismatched, or profile-mismatched context causes a Proxy-local context to be created and never rejects an otherwise valid request. Profile metadata does not select runtime behavior. The propagation freshness rule retains the five-minute maximum age and also accepts only a bounded 30-second future clock skew between Scheduler and Proxy clocks.
 
 `CACHEROUTE_TRACE_SAMPLE_RATE` defaults to `0.0`. Invalid configuration fails
 closed to that value. Rates of zero and one disable or enable collection for
@@ -75,12 +71,13 @@ canonical trace ID. An accepted context retains the Scheduler decision.
 
 The Proxy prepare queue interval starts immediately before `prepare_q.put` and
 finishes at dequeue. The ready queue interval starts immediately before the
-current ready-queue insertion and finishes after the dispatch-turn wait,
-immediately before forwarding. Completion spans downstream handling. For
-streams, first-token spans forwarding to the first non-empty chunk and decode
-spans from that chunk until stream end. Non-streaming requests explicitly skip
-first-token and decode; empty streams explicitly fail first-token and skip
-decode. These are **Proxy-observed transport boundaries**, not authoritative
+current ready-queue insertion, after reservation and prediction work, and
+finishes after the dispatch-turn wait, immediately before forwarding. Completion
+spans downstream handling. For streams, first-token spans forwarding to the first
+non-empty chunk and decode spans from that chunk until stream end. Non-streaming
+requests explicitly skip first-token and decode; an empty successful stream fails
+first-token and completion with the bounded empty-stream error, skips decode, and
+exports a failed request trace. These are **Proxy-observed transport boundaries**, not authoritative
 vLLM execution, prefill, decode, Gateway, or LMCache timings.
 
 Collection remains process-local and immutable. The Legacy trace mapping and

--- a/doc/research/issue-141-unified-observability.md
+++ b/doc/research/issue-141-unified-observability.md
@@ -30,3 +30,10 @@ allow-list. Prediction fields that were overwritten or whose semantics are
 ambiguous remain `legacy_projected`; they cannot be relabeled as actual. Raw
 exceptions, payloads, cache bytes, adapter internals, and unknown trace keys are
 not observability contract data.
+
+Issue #182 adds the first narrow production path: authoritative internal
+Scheduler headers are validated at the Proxy, where sampled prepare-queue,
+ready-queue, and downstream transport stages become a process-local immutable
+trace. The canonical trace still is not client metadata, Instance input, or an
+authoritative account of vLLM or LMCache execution. This increment therefore
+does not close the broader Issue #141 research program.

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -42,7 +42,7 @@ from proxy.strategy.factory import build_instance_strategy
 from proxy.queue import QueueManager, ProxyTask
 from cacheroute.observability import (
     SystemTraceClock, TraceCollector, TracePropagationError,
-    create_trace_context, decode_trace_headers, parse_sample_rate,
+    create_trace_context, decode_trace_headers, resolve_observability_startup,
 )
 from cacheroute.observability.v1 import TraceComponent, TraceProvenance
 from cacheroute.runtime import RuntimeProfile
@@ -77,8 +77,11 @@ INSTANCE_PORT = int(os.environ.get("INSTANCE_PORT", "9001"))
 logger = logging.getLogger("proxy")
 logging.basicConfig(level=logging.INFO)
 
-_PROXY_RUNTIME_PROFILE = RuntimeProfile.resolve_startup(os.environ.get("CACHEROUTE_RUNTIME_PROFILE", "legacy"))
-_PROXY_TRACE_SAMPLE_RATE = parse_sample_rate(os.environ.get("CACHEROUTE_TRACE_SAMPLE_RATE"))
+_DEFAULT_OBSERVABILITY_CONFIG = resolve_observability_startup(v1_available=False)
+
+
+def resolve_proxy_observability_startup(runtime_profile: str | None = None, sample_rate: str | float | None = None):
+    return resolve_observability_startup(runtime_profile, sample_rate, v1_available=False)
 
 
 def _load_static_kdn_links() -> Dict[str, Any]:
@@ -136,8 +139,12 @@ async def lifespan(app: FastAPI):
       - shutdown: unregister gracefully (not required; TTL handles kill -9 cases)
     """
     _squelch_noisy_loggers()
-    app.state.runtime_profile = _PROXY_RUNTIME_PROFILE
-    app.state.trace_sample_rate = _PROXY_TRACE_SAMPLE_RATE
+    obs_config = resolve_proxy_observability_startup(
+        os.environ.get("CACHEROUTE_RUNTIME_PROFILE"),
+        os.environ.get("CACHEROUTE_TRACE_SAMPLE_RATE"),
+    )
+    app.state.runtime_profile = obs_config.runtime_profile
+    app.state.trace_sample_rate = obs_config.trace_sample_rate
     app.state.trace_clock = SystemTraceClock()
     app.state.injection_strategy_name = PROXY_INJECTION_STRATEGY  # type: ignore
     logger.info("[Proxy] injection strategy=%s", app.state.injection_strategy_name)
@@ -344,8 +351,8 @@ def recover_request_from_payload(payload: Dict[str, Any]) -> SchedulerRequest:
 
 def build_proxy_trace(request: FastAPIRequest, request_id: str | int):
     """Accept Scheduler context or create a bounded Proxy-local fallback."""
-    profile = getattr(request.app.state, "runtime_profile", _PROXY_RUNTIME_PROFILE)
-    rate = getattr(request.app.state, "trace_sample_rate", _PROXY_TRACE_SAMPLE_RATE)
+    profile = getattr(request.app.state, "runtime_profile", _DEFAULT_OBSERVABILITY_CONFIG.runtime_profile)
+    rate = getattr(request.app.state, "trace_sample_rate", _DEFAULT_OBSERVABILITY_CONFIG.trace_sample_rate)
     clock = getattr(request.app.state, "trace_clock", None) or SystemTraceClock()
     try:
         context = decode_trace_headers(request.headers, clock=clock)

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -40,6 +40,12 @@ from proxy.resource import p_control_plane
 from proxy.resource.hb_log import HeartbeatReporter, hb_report_loop
 from proxy.strategy.factory import build_instance_strategy
 from proxy.queue import QueueManager, ProxyTask
+from cacheroute.observability import (
+    SystemTraceClock, TraceCollector, TracePropagationError,
+    create_trace_context, decode_trace_headers, parse_sample_rate,
+)
+from cacheroute.observability.v1 import TraceComponent, TraceProvenance
+from cacheroute.runtime import RuntimeProfile
 
 SCHEDULER_CP_URL = os.environ.get("SCHEDULER_CP_URL", config.SCHEDULER_CP_URL).rstrip("/")
 # KDN_BASE_URL = os.environ.get("KDN_BASE_URL", config.KDN_BASE_URL).rstrip("/")
@@ -70,6 +76,9 @@ INSTANCE_PORT = int(os.environ.get("INSTANCE_PORT", "9001"))
 
 logger = logging.getLogger("proxy")
 logging.basicConfig(level=logging.INFO)
+
+_PROXY_RUNTIME_PROFILE = RuntimeProfile.resolve_startup(os.environ.get("CACHEROUTE_RUNTIME_PROFILE", "legacy"))
+_PROXY_TRACE_SAMPLE_RATE = parse_sample_rate(os.environ.get("CACHEROUTE_TRACE_SAMPLE_RATE"))
 
 
 def _load_static_kdn_links() -> Dict[str, Any]:
@@ -127,6 +136,9 @@ async def lifespan(app: FastAPI):
       - shutdown: unregister gracefully (not required; TTL handles kill -9 cases)
     """
     _squelch_noisy_loggers()
+    app.state.runtime_profile = _PROXY_RUNTIME_PROFILE
+    app.state.trace_sample_rate = _PROXY_TRACE_SAMPLE_RATE
+    app.state.trace_clock = SystemTraceClock()
     app.state.injection_strategy_name = PROXY_INJECTION_STRATEGY  # type: ignore
     logger.info("[Proxy] injection strategy=%s", app.state.injection_strategy_name)
     # --- Initialize the instance pool and inject it into the proxy control plane ---
@@ -330,6 +342,28 @@ def recover_request_from_payload(payload: Dict[str, Any]) -> SchedulerRequest:
     return req_obj
 
 
+def build_proxy_trace(request: FastAPIRequest, request_id: str | int):
+    """Accept Scheduler context or create a bounded Proxy-local fallback."""
+    profile = getattr(request.app.state, "runtime_profile", _PROXY_RUNTIME_PROFILE)
+    rate = getattr(request.app.state, "trace_sample_rate", _PROXY_TRACE_SAMPLE_RATE)
+    clock = getattr(request.app.state, "trace_clock", None) or SystemTraceClock()
+    try:
+        context = decode_trace_headers(request.headers, clock=clock)
+        if context.request_id != str(request_id):
+            raise TracePropagationError("request_id_mismatch")
+        if context.runtime_profile is not profile:
+            raise TracePropagationError("profile_mismatch")
+    except TracePropagationError:
+        context = create_trace_context(request_id, profile, sample_rate=rate, clock=clock)
+    collector = TraceCollector(context, clock=clock)
+    provenance = TraceProvenance(
+        source_component=TraceComponent.PROXY,
+        runtime_profile=context.runtime_profile,
+        captured_at=clock.utc_now(),
+    )
+    return context, collector, provenance
+
+
 def build_body_for_instance(req_obj: SchedulerRequest, mode: str) -> Dict[str, Any]:
     """
         Build the OpenAI-style body sent to the Instance from the Request:
@@ -498,6 +532,8 @@ async def proxy_chat_completions(request: FastAPIRequest):
             content={"error": "invalid_request_payload", "detail": str(e)},
         )
 
+    trace_context, trace_collector, trace_provenance = build_proxy_trace(request, req_obj.Request_ID)
+
     # Build the Instance request body
     instance_body = build_body_for_instance(req_obj, mode="chat")
 
@@ -628,6 +664,9 @@ async def proxy_chat_completions(request: FastAPIRequest):
             instance_port=int(chosen.port),
             kdn_addr=getattr(req_obj.Task, "KDN_server_addr", None),
             url_path=url_path,
+            trace_context=trace_context,
+            trace_collector=trace_collector,
+            trace_provenance=trace_provenance,
         )
         task.trace["proxy_recv_ms"] = proxy_recv_ms
         task.trace["route_select_start_ms"] = route_select_start_ms
@@ -674,6 +713,8 @@ async def proxy_completions(request: FastAPIRequest):
             status_code=400,
             content={"error": "invalid_request_payload", "detail": str(e)},
         )
+
+    trace_context, trace_collector, trace_provenance = build_proxy_trace(request, req_obj.Request_ID)
 
     # Build the Instance request body
     instance_body = build_body_for_instance(req_obj, mode="completions")
@@ -805,6 +846,9 @@ async def proxy_completions(request: FastAPIRequest):
             instance_port=int(chosen.port),
             kdn_addr=getattr(req_obj.Task, "KDN_server_addr", None),
             url_path=url_path,
+            trace_context=trace_context,
+            trace_collector=trace_collector,
+            trace_provenance=trace_provenance,
         )
         task.trace["proxy_recv_ms"] = proxy_recv_ms
         task.trace["route_select_start_ms"] = route_select_start_ms

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -146,6 +146,8 @@ async def lifespan(app: FastAPI):
     app.state.runtime_profile = obs_config.runtime_profile
     app.state.trace_sample_rate = obs_config.trace_sample_rate
     app.state.trace_clock = SystemTraceClock()
+    if obs_config.sample_rate_warning_reason is not None:
+        logger.warning("[Proxy] observability startup warning reason=%s", obs_config.sample_rate_warning_reason)
     app.state.injection_strategy_name = PROXY_INJECTION_STRATEGY  # type: ignore
     logger.info("[Proxy] injection strategy=%s", app.state.injection_strategy_name)
     # --- Initialize the instance pool and inject it into the proxy control plane ---

--- a/proxy/queue/manager.py
+++ b/proxy/queue/manager.py
@@ -12,6 +12,8 @@ from typing import Dict, Optional, AsyncGenerator, Any, List, Set
 from core import forward_request,config
 from proxy.metrics.queue_predictor import queue_predictor, decode_tpot_predictor, predict_redis_pull_ms
 from proxy.resource import p_control_plane
+from cacheroute.contracts.v1 import ContractErrorDetail, OutcomeCode
+from cacheroute.observability.v1 import TraceStageName
 
 from .task import ProxyTask
 from .instance_queues import PerInstanceQueueMap
@@ -24,6 +26,9 @@ from .knowledge import (
 )
 
 logger = logging.getLogger("proxy.queue")
+_DOWNSTREAM_FAILED = ContractErrorDetail(code=OutcomeCode.FAILED, message="proxy downstream request failed")
+_EMPTY_STREAM = ContractErrorDetail(code=OutcomeCode.FAILED, message="proxy stream ended before first response")
+_REQUEST_CANCELLED = ContractErrorDetail(code=OutcomeCode.CANCELLED, message="proxy request cancelled")
 
 def _now_ms() -> int:
     return int(time.time() * 1000)
@@ -96,6 +101,35 @@ class QueueManager:
             self._ready_release_policy,
             self._text_bypass_max_per_flush,
         )
+
+    @staticmethod
+    def _start_stage(task: ProxyTask, name: TraceStageName, *, parent: str | None = None) -> str | None:
+        if task.trace_collector is None or task.trace_provenance is None:
+            return None
+        try:
+            return task.trace_collector.start_stage(name, task.trace_provenance, parent_stage_id=parent)
+        except (ValueError, TypeError):
+            logger.warning("[Trace] stage start failed reason=collector_state_invalid")
+            return None
+
+    @staticmethod
+    def _finish_stage(task: ProxyTask, stage_id: str | None, outcome: OutcomeCode,
+                      error: ContractErrorDetail | None = None) -> None:
+        if task.trace_collector is not None:
+            try:
+                task.trace_collector.finish_stage(stage_id, outcome=outcome, error=error)
+            except (ValueError, TypeError):
+                logger.warning("[Trace] stage finalization failed reason=collector_state_invalid")
+
+    @staticmethod
+    def _finalize_trace(task: ProxyTask, outcome: OutcomeCode,
+                        error: ContractErrorDetail | None = None) -> None:
+        if task.trace_collector is None or task.request_trace is not None:
+            return
+        try:
+            task.request_trace = task.trace_collector.export(outcome=outcome, error=error)
+        except Exception:
+            logger.warning("[Trace] finalization failed reason=collector_state_invalid")
 
 
     def queue_depth_snapshot(self) -> Dict[str, Any]:
@@ -352,6 +386,7 @@ class QueueManager:
         task.trace["prepared_buffer_size"] = int(len(buf))
         ready_enqueue_ms = _now_ms()
         task.trace["ready_enqueue_ms"] = ready_enqueue_ms
+        task.ready_queue_stage_id = self._start_stage(task, TraceStageName.PROXY_READY_QUEUE)
         proxy_enqueue_ms = int(task.trace.get("proxy_enqueue_ms", ready_enqueue_ms) or ready_enqueue_ms)
         full_prepare_ms = max(0, ready_enqueue_ms - proxy_enqueue_ms)
         task.trace["predict_know_prepare_ms"] = int(full_prepare_ms)
@@ -878,7 +913,7 @@ class QueueManager:
         enqueue_ms = _now_ms()
         task.trace["proxy_enqueue_ms"] = enqueue_ms
         task.trace["prepare_queue_enqueue_ms"] = enqueue_ms
-
+        task.prepare_queue_stage_id = self._start_stage(task, TraceStageName.PROXY_PREPARE_QUEUE)
         await q.prepare_q.put(task)
         logger.info(
             "[Queue] enqueue_prepare rid=%s instance=%s prepare_len=%s injection=%s",
@@ -1191,6 +1226,23 @@ class QueueManager:
                 task.trace["forward_wait_end_ms"] = _now_ms()
                 task.trace["forward_start_ms"] = _now_ms()
 
+                self._finish_stage(task, task.ready_queue_stage_id, OutcomeCode.SUCCESS)
+                task.ready_queue_stage_id = None
+                task.completion_stage_id = self._start_stage(task, TraceStageName.COMPLETION)
+                if use_chunked:
+                    task.first_token_stage_id = self._start_stage(
+                        task, TraceStageName.FIRST_TOKEN, parent=task.completion_stage_id
+                    )
+                elif task.trace_collector is not None and task.trace_provenance is not None:
+                    task.trace_collector.skip_stage(
+                        TraceStageName.FIRST_TOKEN, task.trace_provenance,
+                        reason="non_streaming_request", parent_stage_id=task.completion_stage_id,
+                    )
+                    task.trace_collector.skip_stage(
+                        TraceStageName.DECODE, task.trace_provenance,
+                        reason="non_streaming_request", parent_stage_id=task.completion_stage_id,
+                    )
+
                 seen_first_chunk = False
                 async for chunk in forward_request(
                     url=target_url,
@@ -1203,6 +1255,11 @@ class QueueManager:
                             task.trace["first_token_ms"] = _now_ms()
                             task.trace["ttft_observable"] = 1 if use_chunked else 0
                             if use_chunked:
+                                self._finish_stage(task, task.first_token_stage_id, OutcomeCode.SUCCESS)
+                                task.first_token_stage_id = None
+                                task.decode_stage_id = self._start_stage(
+                                    task, TraceStageName.DECODE, parent=task.completion_stage_id
+                                )
                                 # Measured latency breakdown, starting from the proxy enqueue timestamp:
                                 # actual_total = proxy_enqueue -> first_token
                                 # actual_know_prepare = proxy_enqueue -> ready_enqueue
@@ -1306,6 +1363,18 @@ class QueueManager:
                         await task.response_queue.put(chunk)
 
                 task.trace["forward_end_ms"] = _now_ms()
+                if use_chunked and not seen_first_chunk:
+                    self._finish_stage(task, task.first_token_stage_id, OutcomeCode.FAILED, _EMPTY_STREAM)
+                    task.first_token_stage_id = None
+                    if task.trace_collector is not None and task.trace_provenance is not None:
+                        task.trace_collector.skip_stage(
+                            TraceStageName.DECODE, task.trace_provenance,
+                            reason="stream_ended_before_decode", parent_stage_id=task.completion_stage_id,
+                        )
+                else:
+                    self._finish_stage(task, task.decode_stage_id, OutcomeCode.SUCCESS)
+                self._finish_stage(task, task.completion_stage_id, OutcomeCode.SUCCESS)
+                self._finalize_trace(task, OutcomeCode.SUCCESS)
                 await self._mark_task_decode_end(task, instance_id)
 
                 # Terminator
@@ -1317,6 +1386,14 @@ class QueueManager:
                     q.active_ready,
                 )
 
+            except asyncio.CancelledError:
+                self._finish_stage(task, task.first_token_stage_id, OutcomeCode.CANCELLED, _REQUEST_CANCELLED)
+                self._finish_stage(task, task.decode_stage_id, OutcomeCode.CANCELLED, _REQUEST_CANCELLED)
+                self._finish_stage(task, task.completion_stage_id, OutcomeCode.CANCELLED, _REQUEST_CANCELLED)
+                self._finish_stage(task, task.ready_queue_stage_id, OutcomeCode.CANCELLED, _REQUEST_CANCELLED)
+                self._finalize_trace(task, OutcomeCode.CANCELLED, _REQUEST_CANCELLED)
+                await task.response_queue.put(None)
+                raise
             except Exception as e:
                 task.error = f"ready_failed: {e}"
                 if "forward_start_ms" not in task.trace:
@@ -1325,6 +1402,11 @@ class QueueManager:
                     task.trace["ttft_observable"] = 0
                     task.trace["first_token_missing_reason"] = "ready_failed_before_first_token"
                 task.trace["forward_end_ms"] = _now_ms()
+                self._finish_stage(task, task.first_token_stage_id, OutcomeCode.FAILED, _DOWNSTREAM_FAILED)
+                self._finish_stage(task, task.decode_stage_id, OutcomeCode.FAILED, _DOWNSTREAM_FAILED)
+                self._finish_stage(task, task.completion_stage_id, OutcomeCode.FAILED, _DOWNSTREAM_FAILED)
+                self._finish_stage(task, task.ready_queue_stage_id, OutcomeCode.FAILED, _DOWNSTREAM_FAILED)
+                self._finalize_trace(task, OutcomeCode.FAILED, _DOWNSTREAM_FAILED)
                 await self._mark_task_decode_end(task, instance_id)
                 logger.exception("[Ready] worker=%s failed rid=%s", worker_idx, task.request_id)
                 # Notify the handler to finish even on error; otherwise the upstream side will hang.
@@ -1342,6 +1424,7 @@ class QueueManager:
         while True:
             task = await q.prepare_q.get()
             task.trace["prepare_dequeue_ms"] = _now_ms()
+            self._finish_stage(task, task.prepare_queue_stage_id, OutcomeCode.SUCCESS)
             asyncio.create_task(self._run_prepare_task(instance_id, task))
 
     async def _inject_ready_kv_via_instance(

--- a/proxy/queue/manager.py
+++ b/proxy/queue/manager.py
@@ -122,6 +122,19 @@ class QueueManager:
                 logger.warning("[Trace] stage finalization failed reason=collector_state_invalid")
 
     @staticmethod
+    def _skip_stage(task: ProxyTask, name: TraceStageName, *, reason: str,
+                    parent: str | None = None) -> str | None:
+        if task.trace_collector is None or task.trace_provenance is None:
+            return None
+        try:
+            return task.trace_collector.skip_stage(
+                name, task.trace_provenance, reason=reason, parent_stage_id=parent
+            )
+        except (ValueError, TypeError):
+            logger.warning("[Trace] stage skip failed reason=collector_state_invalid")
+            return None
+
+    @staticmethod
     def _finalize_trace(task: ProxyTask, outcome: OutcomeCode,
                         error: ContractErrorDetail | None = None) -> None:
         if task.trace_collector is None or task.request_trace is not None:
@@ -1233,14 +1246,14 @@ class QueueManager:
                     task.first_token_stage_id = self._start_stage(
                         task, TraceStageName.FIRST_TOKEN, parent=task.completion_stage_id
                     )
-                elif task.trace_collector is not None and task.trace_provenance is not None:
-                    task.trace_collector.skip_stage(
-                        TraceStageName.FIRST_TOKEN, task.trace_provenance,
-                        reason="non_streaming_request", parent_stage_id=task.completion_stage_id,
+                else:
+                    self._skip_stage(
+                        task, TraceStageName.FIRST_TOKEN,
+                        reason="non_streaming_request", parent=task.completion_stage_id,
                     )
-                    task.trace_collector.skip_stage(
-                        TraceStageName.DECODE, task.trace_provenance,
-                        reason="non_streaming_request", parent_stage_id=task.completion_stage_id,
+                    self._skip_stage(
+                        task, TraceStageName.DECODE,
+                        reason="non_streaming_request", parent=task.completion_stage_id,
                     )
 
                 seen_first_chunk = False
@@ -1370,11 +1383,10 @@ class QueueManager:
                     terminal_error = _EMPTY_STREAM
                     self._finish_stage(task, task.first_token_stage_id, OutcomeCode.FAILED, _EMPTY_STREAM)
                     task.first_token_stage_id = None
-                    if task.trace_collector is not None and task.trace_provenance is not None:
-                        task.trace_collector.skip_stage(
-                            TraceStageName.DECODE, task.trace_provenance,
-                            reason="stream_ended_before_decode", parent_stage_id=task.completion_stage_id,
-                        )
+                    self._skip_stage(
+                        task, TraceStageName.DECODE,
+                        reason="stream_ended_before_decode", parent=task.completion_stage_id,
+                    )
                 else:
                     self._finish_stage(task, task.decode_stage_id, OutcomeCode.SUCCESS)
                 self._finish_stage(task, task.completion_stage_id, terminal_outcome, terminal_error)

--- a/proxy/queue/manager.py
+++ b/proxy/queue/manager.py
@@ -386,7 +386,6 @@ class QueueManager:
         task.trace["prepared_buffer_size"] = int(len(buf))
         ready_enqueue_ms = _now_ms()
         task.trace["ready_enqueue_ms"] = ready_enqueue_ms
-        task.ready_queue_stage_id = self._start_stage(task, TraceStageName.PROXY_READY_QUEUE)
         proxy_enqueue_ms = int(task.trace.get("proxy_enqueue_ms", ready_enqueue_ms) or ready_enqueue_ms)
         full_prepare_ms = max(0, ready_enqueue_ms - proxy_enqueue_ms)
         task.trace["predict_know_prepare_ms"] = int(full_prepare_ms)
@@ -396,6 +395,7 @@ class QueueManager:
         if prepare_self_done_ms > 0:
             task.trace["prepare_buffer_wait_ms"] = max(0, ready_enqueue_ms - prepare_self_done_ms)
         await self._reserve_ready_task(task, now_s=time.time())
+        task.ready_queue_stage_id = self._start_stage(task, TraceStageName.PROXY_READY_QUEUE)
         await q.ready_q.put(task)
         logger.info(
             "[Queue] enqueue_ready rid=%s instance=%s ready_len=%s prepare_seq=%s ready_release_seq=%s bypass=%s blocked_seq=%s",
@@ -1363,7 +1363,11 @@ class QueueManager:
                         await task.response_queue.put(chunk)
 
                 task.trace["forward_end_ms"] = _now_ms()
+                terminal_outcome = OutcomeCode.SUCCESS
+                terminal_error = None
                 if use_chunked and not seen_first_chunk:
+                    terminal_outcome = OutcomeCode.FAILED
+                    terminal_error = _EMPTY_STREAM
                     self._finish_stage(task, task.first_token_stage_id, OutcomeCode.FAILED, _EMPTY_STREAM)
                     task.first_token_stage_id = None
                     if task.trace_collector is not None and task.trace_provenance is not None:
@@ -1373,8 +1377,8 @@ class QueueManager:
                         )
                 else:
                     self._finish_stage(task, task.decode_stage_id, OutcomeCode.SUCCESS)
-                self._finish_stage(task, task.completion_stage_id, OutcomeCode.SUCCESS)
-                self._finalize_trace(task, OutcomeCode.SUCCESS)
+                self._finish_stage(task, task.completion_stage_id, terminal_outcome, terminal_error)
+                self._finalize_trace(task, terminal_outcome, terminal_error)
                 await self._mark_task_decode_end(task, instance_id)
 
                 # Terminator

--- a/proxy/queue/task.py
+++ b/proxy/queue/task.py
@@ -7,6 +7,9 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, List
 
+from cacheroute.observability import TraceCollector
+from cacheroute.observability.v1 import RequestTrace, TraceContext, TraceProvenance
+
 
 @dataclass
 class ProxyTask:
@@ -52,6 +55,18 @@ class ProxyTask:
 
     kv_ack: Dict[str, Any] = field(default_factory=dict)
     trace: Dict[str, int] = field(default_factory=dict)
+
+    # Canonical observability is process-local and independent of the Legacy
+    # free-form mapping above. Existing callers may omit every field.
+    trace_context: Optional[TraceContext] = None
+    trace_collector: Optional[TraceCollector] = None
+    request_trace: Optional[RequestTrace] = None
+    trace_provenance: Optional[TraceProvenance] = None
+    prepare_queue_stage_id: Optional[str] = None
+    ready_queue_stage_id: Optional[str] = None
+    completion_stage_id: Optional[str] = None
+    first_token_stage_id: Optional[str] = None
+    decode_stage_id: Optional[str] = None
 
     # reservation state for ready/prefill timeline
     # prediction stage: "prefill" (default) or "decode" (reserved for future modeling)

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -69,17 +69,19 @@ from .strategy import create_strategy
 
 from util import timing
 from cacheroute.observability import (
-    SystemTraceClock, create_trace_context, encode_trace_headers, parse_sample_rate,
+    SystemTraceClock, create_trace_context, encode_trace_headers,
+    resolve_observability_startup,
 )
 from cacheroute.runtime import RuntimeProfile
 
 # Use a fallback default when no external value is provided, making local runs easier
 from core.config import DEFAULT_MODEL, DEFAULT_EMBED_MODEL, SCHEDULER_CP_PORT
 
-_SCHEDULER_RUNTIME_PROFILE = RuntimeProfile.resolve_startup(
-    os.environ.get("CACHEROUTE_RUNTIME_PROFILE", "legacy")
-)
-_SCHEDULER_TRACE_SAMPLE_RATE = parse_sample_rate(os.environ.get("CACHEROUTE_TRACE_SAMPLE_RATE"))
+_DEFAULT_OBSERVABILITY_CONFIG = resolve_observability_startup(v1_available=False)
+
+
+def resolve_scheduler_observability_startup(runtime_profile: str | None = None, sample_rate: str | float | None = None):
+    return resolve_observability_startup(runtime_profile, sample_rate, v1_available=False)
 
 
 # ======================= Request ID allocator and other basic functions=======================
@@ -221,8 +223,12 @@ async def lifespan(app: FastAPI):
       - shutdown: no resources to clean up currently; interface reserved
     """
     log_path = init_logging()
-    app.state.runtime_profile = _SCHEDULER_RUNTIME_PROFILE
-    app.state.trace_sample_rate = _SCHEDULER_TRACE_SAMPLE_RATE
+    obs_config = resolve_scheduler_observability_startup(
+        os.environ.get("CACHEROUTE_RUNTIME_PROFILE"),
+        os.environ.get("CACHEROUTE_TRACE_SAMPLE_RATE"),
+    )
+    app.state.runtime_profile = obs_config.runtime_profile
+    app.state.trace_sample_rate = obs_config.trace_sample_rate
     app.state.trace_clock = SystemTraceClock()
     print(f"[Scheduler] started. log_file={log_path}")
     # ------------------------------------------
@@ -372,8 +378,8 @@ def build_proxy_headers(app: FastAPI, raw_headers: Dict[str, str], request_id: s
         outgoing["authorization"] = raw_headers["authorization"]
     context = create_trace_context(
         request_id,
-        getattr(app.state, "runtime_profile", _SCHEDULER_RUNTIME_PROFILE),
-        sample_rate=getattr(app.state, "trace_sample_rate", _SCHEDULER_TRACE_SAMPLE_RATE),
+        getattr(app.state, "runtime_profile", _DEFAULT_OBSERVABILITY_CONFIG.runtime_profile),
+        sample_rate=getattr(app.state, "trace_sample_rate", _DEFAULT_OBSERVABILITY_CONFIG.trace_sample_rate),
         clock=getattr(app.state, "trace_clock", None) or SystemTraceClock(),
     )
     outgoing.update(encode_trace_headers(context))

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -230,6 +230,8 @@ async def lifespan(app: FastAPI):
     app.state.runtime_profile = obs_config.runtime_profile
     app.state.trace_sample_rate = obs_config.trace_sample_rate
     app.state.trace_clock = SystemTraceClock()
+    if obs_config.sample_rate_warning_reason is not None:
+        logger.warning("[Scheduler] observability startup warning reason=%s", obs_config.sample_rate_warning_reason)
     print(f"[Scheduler] started. log_file={log_path}")
     # ------------------------------------------
     # Try to warm up the tokenizer

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -68,9 +68,18 @@ from .strategy import create_strategy
 # )
 
 from util import timing
+from cacheroute.observability import (
+    SystemTraceClock, create_trace_context, encode_trace_headers, parse_sample_rate,
+)
+from cacheroute.runtime import RuntimeProfile
 
 # Use a fallback default when no external value is provided, making local runs easier
 from core.config import DEFAULT_MODEL, DEFAULT_EMBED_MODEL, SCHEDULER_CP_PORT
+
+_SCHEDULER_RUNTIME_PROFILE = RuntimeProfile.resolve_startup(
+    os.environ.get("CACHEROUTE_RUNTIME_PROFILE", "legacy")
+)
+_SCHEDULER_TRACE_SAMPLE_RATE = parse_sample_rate(os.environ.get("CACHEROUTE_TRACE_SAMPLE_RATE"))
 
 
 # ======================= Request ID allocator and other basic functions=======================
@@ -212,6 +221,9 @@ async def lifespan(app: FastAPI):
       - shutdown: no resources to clean up currently; interface reserved
     """
     log_path = init_logging()
+    app.state.runtime_profile = _SCHEDULER_RUNTIME_PROFILE
+    app.state.trace_sample_rate = _SCHEDULER_TRACE_SAMPLE_RATE
+    app.state.trace_clock = SystemTraceClock()
     print(f"[Scheduler] started. log_file={log_path}")
     # ------------------------------------------
     # Try to warm up the tokenizer
@@ -351,6 +363,21 @@ scheduler = FastAPI(
     version="0.1.1",
     lifespan=lifespan,
 )
+
+
+def build_proxy_headers(app: FastAPI, raw_headers: Dict[str, str], request_id: str | int) -> Dict[str, str]:
+    """Create authoritative internal headers without trusting client trace fields."""
+    outgoing: Dict[str, str] = {}
+    if "authorization" in raw_headers:
+        outgoing["authorization"] = raw_headers["authorization"]
+    context = create_trace_context(
+        request_id,
+        getattr(app.state, "runtime_profile", _SCHEDULER_RUNTIME_PROFILE),
+        sample_rate=getattr(app.state, "trace_sample_rate", _SCHEDULER_TRACE_SAMPLE_RATE),
+        clock=getattr(app.state, "trace_clock", None) or SystemTraceClock(),
+    )
+    outgoing.update(encode_trace_headers(context))
+    return outgoing
 
 
 
@@ -506,14 +533,7 @@ async def create_chat_completions(request: FastAPIRequest):
     data_for_downstream = req_obj.to_payload()
 
     # Handle headers that need to be passed through downstream, optionally filtering them
-    extra_headers = {}
-
-    # Pass the user Authorization downstream unchanged if Proxy should perform authentication
-    if "authorization" in raw_headers:
-        extra_headers["authorization"] = raw_headers["authorization"]
-
-    # Carry a Scheduler-assigned Request ID for traceability
-    extra_headers["scheduler-request-id"] = str(req_obj.Request_ID)
+    extra_headers = build_proxy_headers(request.app, raw_headers, req_obj.Request_ID)
 
     # Define an async generator that reads streaming data from downstream and returns it upstream
     async def iter_upstream():
@@ -630,14 +650,7 @@ async def create_completions(request: FastAPIRequest):
     data_for_downstream = req_obj.to_payload()
 
     # Handle headers that need to be passed through downstream, optionally filtering them
-    extra_headers = {}
-
-    # Pass the user Authorization downstream unchanged if Proxy should perform authentication
-    if "authorization" in raw_headers:
-        extra_headers["authorization"] = raw_headers["authorization"]
-
-    # Carry a Scheduler-assigned Request ID for traceability
-    extra_headers["scheduler-request-id"] = str(req_obj.Request_ID)
+    extra_headers = build_proxy_headers(request.app, raw_headers, req_obj.Request_ID)
 
     # Define an async generator that reads streaming data from downstream and returns it upstream
     async def iter_upstream():

--- a/src/cacheroute/observability/__init__.py
+++ b/src/cacheroute/observability/__init__.py
@@ -8,7 +8,7 @@ from .propagation import (
     decode_trace_headers, encode_trace_headers, is_trace_sampled,
     new_trace_id, parse_sample_rate,
 )
-from .startup import ObservabilityStartupConfig, resolve_observability_startup
+from .startup import ObservabilityStartupConfig, resolve_observability_startup, sample_rate_warning_reason
 
 __all__ = [
     "TraceClock", "SystemTraceClock", "ManualTraceClock", "TraceCollector",
@@ -16,5 +16,5 @@ __all__ = [
     "RESERVED_TRACE_HEADERS", "TracePropagationError", "create_trace_context",
     "decode_trace_headers", "encode_trace_headers", "is_trace_sampled",
     "new_trace_id", "parse_sample_rate",
-    "ObservabilityStartupConfig", "resolve_observability_startup",
+    "ObservabilityStartupConfig", "resolve_observability_startup", "sample_rate_warning_reason",
 ]

--- a/src/cacheroute/observability/__init__.py
+++ b/src/cacheroute/observability/__init__.py
@@ -3,8 +3,16 @@
 from .clock import ManualTraceClock, SystemTraceClock, TraceClock
 from .collector import TraceCollector
 from .legacy_proxy import project_legacy_proxy_trace
+from .propagation import (
+    RESERVED_TRACE_HEADERS, TracePropagationError, create_trace_context,
+    decode_trace_headers, encode_trace_headers, is_trace_sampled,
+    new_trace_id, parse_sample_rate,
+)
 
 __all__ = [
     "TraceClock", "SystemTraceClock", "ManualTraceClock", "TraceCollector",
     "project_legacy_proxy_trace",
+    "RESERVED_TRACE_HEADERS", "TracePropagationError", "create_trace_context",
+    "decode_trace_headers", "encode_trace_headers", "is_trace_sampled",
+    "new_trace_id", "parse_sample_rate",
 ]

--- a/src/cacheroute/observability/__init__.py
+++ b/src/cacheroute/observability/__init__.py
@@ -8,6 +8,7 @@ from .propagation import (
     decode_trace_headers, encode_trace_headers, is_trace_sampled,
     new_trace_id, parse_sample_rate,
 )
+from .startup import ObservabilityStartupConfig, resolve_observability_startup
 
 __all__ = [
     "TraceClock", "SystemTraceClock", "ManualTraceClock", "TraceCollector",
@@ -15,4 +16,5 @@ __all__ = [
     "RESERVED_TRACE_HEADERS", "TracePropagationError", "create_trace_context",
     "decode_trace_headers", "encode_trace_headers", "is_trace_sampled",
     "new_trace_id", "parse_sample_rate",
+    "ObservabilityStartupConfig", "resolve_observability_startup",
 ]

--- a/src/cacheroute/observability/propagation.py
+++ b/src/cacheroute/observability/propagation.py
@@ -1,0 +1,160 @@
+"""Canonical Scheduler-to-Proxy trace-context propagation.
+
+This module deliberately contains no service configuration or I/O.  Services
+resolve startup settings and pass the resulting values into these helpers.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+import hashlib
+import math
+import re
+from uuid import uuid4
+
+from cacheroute.runtime import RuntimeProfile
+from .clock import SystemTraceClock, TraceClock
+from .v1 import TraceContext
+from .v1.models import OBSERVABILITY_SCHEMA_VERSION
+
+REQUEST_ID_HEADER = "scheduler-request-id"
+TRACE_VERSION_HEADER = "x-cacheroute-trace-version"
+TRACE_ID_HEADER = "x-cacheroute-trace-id"
+RUNTIME_PROFILE_HEADER = "x-cacheroute-runtime-profile"
+TRACE_SAMPLED_HEADER = "x-cacheroute-trace-sampled"
+TRACE_CREATED_AT_HEADER = "x-cacheroute-trace-created-at"
+
+RESERVED_TRACE_HEADERS = (
+    REQUEST_ID_HEADER,
+    TRACE_VERSION_HEADER,
+    TRACE_ID_HEADER,
+    RUNTIME_PROFILE_HEADER,
+    TRACE_SAMPLED_HEADER,
+    TRACE_CREATED_AT_HEADER,
+)
+_TRACE_ID = re.compile(r"^trace_[0-9a-f]{32}$")
+_MAX_AGE = timedelta(minutes=5)
+
+
+class TracePropagationError(ValueError):
+    """A bounded, value-free propagation validation failure."""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        super().__init__(reason)
+
+
+def parse_sample_rate(value: str | float | None) -> float:
+    """Return a safe rate, failing closed for malformed startup input."""
+    try:
+        rate = float(value if value is not None else 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+    return rate if math.isfinite(rate) and 0.0 <= rate <= 1.0 else 0.0
+
+
+def is_trace_sampled(trace_id: str, sample_rate: float) -> bool:
+    if _TRACE_ID.fullmatch(trace_id) is None:
+        raise ValueError("trace_id_invalid")
+    rate = parse_sample_rate(sample_rate)
+    if rate <= 0.0:
+        return False
+    if rate >= 1.0:
+        return True
+    bucket = int.from_bytes(hashlib.sha256(trace_id.encode("ascii")).digest()[:8], "big")
+    return bucket < int(rate * (1 << 64))
+
+
+def new_trace_id() -> str:
+    return f"trace_{uuid4().hex}"
+
+
+def create_trace_context(request_id: str | int, runtime_profile: RuntimeProfile, *,
+                         sample_rate: float = 0.0, clock: TraceClock | None = None,
+                         trace_id: str | None = None) -> TraceContext:
+    profile = RuntimeProfile.normalize(runtime_profile)
+    if profile is RuntimeProfile.AUTO:
+        raise ValueError("runtime_profile_auto")
+    identifier = trace_id or new_trace_id()
+    if _TRACE_ID.fullmatch(identifier) is None:
+        raise ValueError("trace_id_invalid")
+    return TraceContext(
+        trace_id=identifier,
+        request_id=str(request_id),
+        runtime_profile=profile,
+        sampled=is_trace_sampled(identifier, sample_rate),
+        created_at=(clock or SystemTraceClock()).utc_now(),
+    )
+
+
+def encode_trace_headers(context: TraceContext) -> dict[str, str]:
+    if _TRACE_ID.fullmatch(context.trace_id) is None:
+        raise TracePropagationError("trace_id_invalid")
+    if context.runtime_profile is RuntimeProfile.AUTO:
+        raise TracePropagationError("profile_invalid")
+    if context.created_at.utcoffset() != timedelta(0):
+        raise TracePropagationError("created_at_invalid")
+    return {
+        REQUEST_ID_HEADER: context.request_id,
+        TRACE_VERSION_HEADER: OBSERVABILITY_SCHEMA_VERSION,
+        TRACE_ID_HEADER: context.trace_id,
+        RUNTIME_PROFILE_HEADER: context.runtime_profile.value,
+        TRACE_SAMPLED_HEADER: "1" if context.sampled else "0",
+        TRACE_CREATED_AT_HEADER: context.created_at.isoformat(timespec="microseconds").replace("+00:00", "Z"),
+    }
+
+
+def decode_trace_headers(headers: Mapping[str, str], *, clock: TraceClock | None = None,
+                         max_age: timedelta = _MAX_AGE) -> TraceContext:
+    lowered: dict[str, str] = {}
+    for key, value in headers.items():
+        name = str(key).lower()
+        if name.startswith("x-cacheroute-trace-") and name not in RESERVED_TRACE_HEADERS:
+            raise TracePropagationError("header_unknown")
+        if name in RESERVED_TRACE_HEADERS:
+            if name in lowered and lowered[name] != str(value):
+                raise TracePropagationError("header_conflict")
+            lowered[name] = str(value)
+    if set(lowered) != set(RESERVED_TRACE_HEADERS):
+        raise TracePropagationError("headers_incomplete")
+    if lowered[TRACE_VERSION_HEADER] != OBSERVABILITY_SCHEMA_VERSION:
+        raise TracePropagationError("version_invalid")
+    trace_id = lowered[TRACE_ID_HEADER]
+    if _TRACE_ID.fullmatch(trace_id) is None:
+        raise TracePropagationError("trace_id_invalid")
+    try:
+        profile = RuntimeProfile.normalize(lowered[RUNTIME_PROFILE_HEADER])
+    except ValueError as exc:
+        raise TracePropagationError("profile_invalid") from exc
+    if profile is RuntimeProfile.AUTO:
+        raise TracePropagationError("profile_invalid")
+    sampled_value = lowered[TRACE_SAMPLED_HEADER]
+    if sampled_value not in {"0", "1"}:
+        raise TracePropagationError("sampled_invalid")
+    stamp_value = lowered[TRACE_CREATED_AT_HEADER]
+    try:
+        created_at = datetime.fromisoformat(stamp_value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise TracePropagationError("created_at_invalid") from exc
+    if created_at.utcoffset() != timedelta(0):
+        raise TracePropagationError("created_at_invalid")
+    now = (clock or SystemTraceClock()).utc_now()
+    if created_at > now or now - created_at > max_age:
+        raise TracePropagationError("created_at_stale")
+    try:
+        return TraceContext(
+            schema_version=lowered[TRACE_VERSION_HEADER], trace_id=trace_id,
+            request_id=lowered[REQUEST_ID_HEADER], runtime_profile=profile,
+            sampled=sampled_value == "1", created_at=created_at,
+        )
+    except ValueError as exc:
+        raise TracePropagationError("context_invalid") from exc
+
+
+__all__ = [
+    "REQUEST_ID_HEADER", "TRACE_VERSION_HEADER", "TRACE_ID_HEADER",
+    "RUNTIME_PROFILE_HEADER", "TRACE_SAMPLED_HEADER", "TRACE_CREATED_AT_HEADER",
+    "RESERVED_TRACE_HEADERS", "TracePropagationError", "parse_sample_rate",
+    "is_trace_sampled", "new_trace_id", "create_trace_context",
+    "encode_trace_headers", "decode_trace_headers",
+]

--- a/src/cacheroute/observability/propagation.py
+++ b/src/cacheroute/observability/propagation.py
@@ -34,6 +34,9 @@ RESERVED_TRACE_HEADERS = (
 )
 _TRACE_ID = re.compile(r"^trace_[0-9a-f]{32}$")
 _MAX_AGE = timedelta(minutes=5)
+# Scheduler and Proxy clocks may differ slightly during startup or host sync.
+# Accept only this bounded future skew and retain the maximum-age freshness rule.
+_FUTURE_SKEW_TOLERANCE = timedelta(seconds=30)
 
 
 class TracePropagationError(ValueError):
@@ -105,7 +108,8 @@ def encode_trace_headers(context: TraceContext) -> dict[str, str]:
 
 
 def decode_trace_headers(headers: Mapping[str, str], *, clock: TraceClock | None = None,
-                         max_age: timedelta = _MAX_AGE) -> TraceContext:
+                         max_age: timedelta = _MAX_AGE,
+                         future_skew_tolerance: timedelta = _FUTURE_SKEW_TOLERANCE) -> TraceContext:
     lowered: dict[str, str] = {}
     for key, value in headers.items():
         name = str(key).lower()
@@ -139,7 +143,7 @@ def decode_trace_headers(headers: Mapping[str, str], *, clock: TraceClock | None
     if created_at.utcoffset() != timedelta(0):
         raise TracePropagationError("created_at_invalid")
     now = (clock or SystemTraceClock()).utc_now()
-    if created_at > now or now - created_at > max_age:
+    if created_at - now > future_skew_tolerance or now - created_at > max_age:
         raise TracePropagationError("created_at_stale")
     try:
         return TraceContext(
@@ -155,6 +159,7 @@ __all__ = [
     "REQUEST_ID_HEADER", "TRACE_VERSION_HEADER", "TRACE_ID_HEADER",
     "RUNTIME_PROFILE_HEADER", "TRACE_SAMPLED_HEADER", "TRACE_CREATED_AT_HEADER",
     "RESERVED_TRACE_HEADERS", "TracePropagationError", "parse_sample_rate",
+    "_MAX_AGE", "_FUTURE_SKEW_TOLERANCE",
     "is_trace_sampled", "new_trace_id", "create_trace_context",
     "encode_trace_headers", "decode_trace_headers",
 ]

--- a/src/cacheroute/observability/startup.py
+++ b/src/cacheroute/observability/startup.py
@@ -1,0 +1,34 @@
+"""Service startup configuration for dependency-light observability helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cacheroute.runtime import RuntimeProfile
+from .propagation import parse_sample_rate
+
+
+@dataclass(frozen=True)
+class ObservabilityStartupConfig:
+    runtime_profile: RuntimeProfile
+    trace_sample_rate: float
+
+
+def resolve_observability_startup(
+    runtime_profile: RuntimeProfile | str | None = None,
+    trace_sample_rate: str | float | None = None,
+    *,
+    v1_available: bool = False,
+) -> ObservabilityStartupConfig:
+    """Resolve startup-only observability metadata once for a service lifespan.
+
+    Current Scheduler and Proxy service paths do not have a production v1 data
+    path, so callers pass ``v1_available=False`` and ``auto`` resolves to
+    ``legacy`` before any context can be persisted or propagated.
+    """
+    return ObservabilityStartupConfig(
+        runtime_profile=RuntimeProfile.resolve_startup(runtime_profile if runtime_profile is not None else RuntimeProfile.LEGACY.value, v1_available=v1_available),
+        trace_sample_rate=parse_sample_rate(trace_sample_rate),
+    )
+
+
+__all__ = ["ObservabilityStartupConfig", "resolve_observability_startup"]

--- a/src/cacheroute/observability/startup.py
+++ b/src/cacheroute/observability/startup.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 
 from cacheroute.runtime import RuntimeProfile
 from .propagation import parse_sample_rate
@@ -11,6 +12,7 @@ from .propagation import parse_sample_rate
 class ObservabilityStartupConfig:
     runtime_profile: RuntimeProfile
     trace_sample_rate: float
+    sample_rate_warning_reason: str | None = None
 
 
 def resolve_observability_startup(
@@ -28,7 +30,24 @@ def resolve_observability_startup(
     return ObservabilityStartupConfig(
         runtime_profile=RuntimeProfile.resolve_startup(runtime_profile if runtime_profile is not None else RuntimeProfile.LEGACY.value, v1_available=v1_available),
         trace_sample_rate=parse_sample_rate(trace_sample_rate),
+        sample_rate_warning_reason=sample_rate_warning_reason(trace_sample_rate),
     )
 
 
-__all__ = ["ObservabilityStartupConfig", "resolve_observability_startup"]
+def sample_rate_warning_reason(value: str | float | None) -> str | None:
+    if value is None:
+        return None
+    try:
+        rate = float(value)
+    except (TypeError, ValueError):
+        return "trace_sample_rate_malformed"
+    if not math.isfinite(rate):
+        return "trace_sample_rate_non_finite"
+    if rate < 0.0:
+        return "trace_sample_rate_below_zero"
+    if rate > 1.0:
+        return "trace_sample_rate_above_one"
+    return None
+
+
+__all__ = ["ObservabilityStartupConfig", "resolve_observability_startup", "sample_rate_warning_reason"]

--- a/test/observability/test_models.py
+++ b/test/observability/test_models.py
@@ -34,7 +34,28 @@ def context(**updates):
 
 def test_public_surfaces_and_canonical_identity():
     assert api.__all__ == ["TraceContext", "TraceComponent", "TraceStageName", "TraceStageState", "TraceValueKind", "TraceProvenance", "TraceMeasurement", "TraceStage", "RequestTrace", "CacheOperationTrace", "OperationWaiterLink", "OperationWaiterState"]
-    assert helpers.__all__ == ["TraceClock", "SystemTraceClock", "ManualTraceClock", "TraceCollector", "project_legacy_proxy_trace"]
+    assert helpers.__all__ == [
+        "TraceClock", "SystemTraceClock", "ManualTraceClock", "TraceCollector",
+        "project_legacy_proxy_trace",
+        "RESERVED_TRACE_HEADERS", "TracePropagationError", "create_trace_context",
+        "decode_trace_headers", "encode_trace_headers", "is_trace_sampled",
+        "new_trace_id", "parse_sample_rate",
+        "ObservabilityStartupConfig", "resolve_observability_startup",
+    ]
+    import cacheroute.observability.propagation as propagation
+    import cacheroute.observability.startup as startup
+    assert helpers.RESERVED_TRACE_HEADERS is propagation.RESERVED_TRACE_HEADERS
+    assert helpers.TracePropagationError is propagation.TracePropagationError
+    assert helpers.create_trace_context is propagation.create_trace_context
+    assert helpers.decode_trace_headers is propagation.decode_trace_headers
+    assert helpers.encode_trace_headers is propagation.encode_trace_headers
+    assert helpers.is_trace_sampled is propagation.is_trace_sampled
+    assert helpers.new_trace_id is propagation.new_trace_id
+    assert helpers.parse_sample_rate is propagation.parse_sample_rate
+    assert helpers.ObservabilityStartupConfig is startup.ObservabilityStartupConfig
+    assert helpers.resolve_observability_startup is startup.resolve_observability_startup
+    assert helpers.create_trace_context.__module__ == "cacheroute.observability.propagation"
+    assert helpers.resolve_observability_startup.__module__ == "cacheroute.observability.startup"
     assert ReusedRuntime is RuntimeProfile
     assert ReusedOutcome is OutcomeCode
     assert ReusedError is ContractErrorDetail

--- a/test/observability/test_models.py
+++ b/test/observability/test_models.py
@@ -40,7 +40,7 @@ def test_public_surfaces_and_canonical_identity():
         "RESERVED_TRACE_HEADERS", "TracePropagationError", "create_trace_context",
         "decode_trace_headers", "encode_trace_headers", "is_trace_sampled",
         "new_trace_id", "parse_sample_rate",
-        "ObservabilityStartupConfig", "resolve_observability_startup",
+        "ObservabilityStartupConfig", "resolve_observability_startup", "sample_rate_warning_reason",
     ]
     import cacheroute.observability.propagation as propagation
     import cacheroute.observability.startup as startup
@@ -54,6 +54,7 @@ def test_public_surfaces_and_canonical_identity():
     assert helpers.parse_sample_rate is propagation.parse_sample_rate
     assert helpers.ObservabilityStartupConfig is startup.ObservabilityStartupConfig
     assert helpers.resolve_observability_startup is startup.resolve_observability_startup
+    assert helpers.sample_rate_warning_reason is startup.sample_rate_warning_reason
     assert helpers.create_trace_context.__module__ == "cacheroute.observability.propagation"
     assert helpers.resolve_observability_startup.__module__ == "cacheroute.observability.startup"
     assert ReusedRuntime is RuntimeProfile

--- a/test/observability/test_propagation.py
+++ b/test/observability/test_propagation.py
@@ -6,7 +6,9 @@ from cacheroute.observability import ManualTraceClock
 from cacheroute.observability.propagation import (
     RESERVED_TRACE_HEADERS, TracePropagationError, create_trace_context,
     decode_trace_headers, encode_trace_headers, is_trace_sampled, parse_sample_rate,
+    _FUTURE_SKEW_TOLERANCE, _MAX_AGE,
 )
+from cacheroute.observability.startup import resolve_observability_startup
 from cacheroute.runtime import RuntimeProfile
 
 NOW = datetime(2026, 8, 4, 12, tzinfo=timezone.utc)
@@ -45,10 +47,14 @@ def test_malformed_context_is_rejected(change):
         decode_trace_headers(headers, clock=ManualTraceClock(NOW))
 
 
-def test_stale_and_future_timestamps_are_rejected():
-    for now in (NOW - timedelta(seconds=1), NOW + timedelta(minutes=6)):
-        with pytest.raises(TracePropagationError):
-            decode_trace_headers(encode_trace_headers(context()), clock=ManualTraceClock(now))
+def test_timestamp_freshness_boundaries():
+    headers = encode_trace_headers(context())
+    decode_trace_headers(headers, clock=ManualTraceClock(NOW - _FUTURE_SKEW_TOLERANCE))
+    with pytest.raises(TracePropagationError):
+        decode_trace_headers(headers, clock=ManualTraceClock(NOW - _FUTURE_SKEW_TOLERANCE - timedelta(microseconds=1)))
+    decode_trace_headers(headers, clock=ManualTraceClock(NOW + _MAX_AGE))
+    with pytest.raises(TracePropagationError):
+        decode_trace_headers(headers, clock=ManualTraceClock(NOW + _MAX_AGE + timedelta(microseconds=1)))
 
 
 def test_sampling_boundaries_and_invalid_configuration():
@@ -57,3 +63,17 @@ def test_sampling_boundaries_and_invalid_configuration():
     assert is_trace_sampled(TRACE_ID, 0.5) == is_trace_sampled(TRACE_ID, 0.5)
     for value in (None, "bad", "nan", "inf", -1, 2):
         assert parse_sample_rate(value) == 0.0
+
+
+@pytest.mark.parametrize(("value", "expected"), [
+    (None, RuntimeProfile.LEGACY),
+    ("legacy", RuntimeProfile.LEGACY),
+    ("test/mock", RuntimeProfile.TEST_MOCK),
+    ("v1", RuntimeProfile.V1),
+    ("auto", RuntimeProfile.LEGACY),
+])
+def test_current_service_startup_profile_resolution(value, expected):
+    config = resolve_observability_startup(value, "1.0", v1_available=False)
+    assert config.runtime_profile is expected
+    assert config.runtime_profile is not RuntimeProfile.AUTO
+    assert config.trace_sample_rate == 1.0

--- a/test/observability/test_propagation.py
+++ b/test/observability/test_propagation.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cacheroute.observability import ManualTraceClock
+from cacheroute.observability.propagation import (
+    RESERVED_TRACE_HEADERS, TracePropagationError, create_trace_context,
+    decode_trace_headers, encode_trace_headers, is_trace_sampled, parse_sample_rate,
+)
+from cacheroute.runtime import RuntimeProfile
+
+NOW = datetime(2026, 8, 4, 12, tzinfo=timezone.utc)
+TRACE_ID = "trace_0123456789abcdef0123456789abcdef"
+
+
+def context(sample_rate=1.0):
+    return create_trace_context("42", RuntimeProfile.LEGACY, sample_rate=sample_rate,
+                                clock=ManualTraceClock(NOW), trace_id=TRACE_ID)
+
+
+def test_exact_vocabulary_and_deterministic_round_trip():
+    headers = encode_trace_headers(context())
+    assert tuple(headers) == RESERVED_TRACE_HEADERS
+    assert decode_trace_headers(headers, clock=ManualTraceClock(NOW)) == context()
+    assert encode_trace_headers(decode_trace_headers(headers, clock=ManualTraceClock(NOW))) == headers
+
+
+def test_decode_is_case_insensitive():
+    headers = {key.upper(): value for key, value in encode_trace_headers(context()).items()}
+    assert decode_trace_headers(headers, clock=ManualTraceClock(NOW)).trace_id == TRACE_ID
+
+
+@pytest.mark.parametrize("change", [
+    lambda h: h.pop("x-cacheroute-trace-id"),
+    lambda h: h.__setitem__("x-cacheroute-trace-id", "TRACE_bad"),
+    lambda h: h.__setitem__("x-cacheroute-trace-sampled", "true"),
+    lambda h: h.__setitem__("x-cacheroute-runtime-profile", "auto"),
+    lambda h: h.__setitem__("x-cacheroute-trace-created-at", "2026-08-04T12:00:00+01:00"),
+    lambda h: h.__setitem__("x-cacheroute-trace-extra", "x"),
+])
+def test_malformed_context_is_rejected(change):
+    headers = encode_trace_headers(context())
+    change(headers)
+    with pytest.raises(TracePropagationError):
+        decode_trace_headers(headers, clock=ManualTraceClock(NOW))
+
+
+def test_stale_and_future_timestamps_are_rejected():
+    for now in (NOW - timedelta(seconds=1), NOW + timedelta(minutes=6)):
+        with pytest.raises(TracePropagationError):
+            decode_trace_headers(encode_trace_headers(context()), clock=ManualTraceClock(now))
+
+
+def test_sampling_boundaries_and_invalid_configuration():
+    assert not is_trace_sampled(TRACE_ID, 0.0)
+    assert is_trace_sampled(TRACE_ID, 1.0)
+    assert is_trace_sampled(TRACE_ID, 0.5) == is_trace_sampled(TRACE_ID, 0.5)
+    for value in (None, "bad", "nan", "inf", -1, 2):
+        assert parse_sample_rate(value) == 0.0

--- a/test/observability/test_propagation.py
+++ b/test/observability/test_propagation.py
@@ -4,11 +4,11 @@ import pytest
 
 from cacheroute.observability import ManualTraceClock
 from cacheroute.observability.propagation import (
-    RESERVED_TRACE_HEADERS, TracePropagationError, create_trace_context,
-    decode_trace_headers, encode_trace_headers, is_trace_sampled, parse_sample_rate,
+    RESERVED_TRACE_HEADERS, TRACE_VERSION_HEADER, TracePropagationError, create_trace_context,
+    decode_trace_headers, encode_trace_headers, is_trace_sampled, new_trace_id, parse_sample_rate,
     _FUTURE_SKEW_TOLERANCE, _MAX_AGE,
 )
-from cacheroute.observability.startup import resolve_observability_startup
+from cacheroute.observability.startup import resolve_observability_startup, sample_rate_warning_reason
 from cacheroute.runtime import RuntimeProfile
 
 NOW = datetime(2026, 8, 4, 12, tzinfo=timezone.utc)
@@ -77,3 +77,51 @@ def test_current_service_startup_profile_resolution(value, expected):
     assert config.runtime_profile is expected
     assert config.runtime_profile is not RuntimeProfile.AUTO
     assert config.trace_sample_rate == 1.0
+
+
+def test_generated_trace_id_syntax():
+    trace_id = new_trace_id()
+    assert trace_id.startswith("trace_")
+    assert len(trace_id) == len("trace_") + 32
+    assert trace_id == trace_id.lower()
+    int(trace_id.removeprefix("trace_"), 16)
+
+
+def test_missing_malformed_version_and_conflicting_headers():
+    with pytest.raises(TracePropagationError, match="headers_incomplete"):
+        decode_trace_headers({}, clock=ManualTraceClock(NOW))
+    bad = encode_trace_headers(context())
+    bad[TRACE_VERSION_HEADER] = "observability.v2"
+    with pytest.raises(TracePropagationError, match="version_invalid"):
+        decode_trace_headers(bad, clock=ManualTraceClock(NOW))
+    class DuplicateHeaders:
+        def items(self):
+            values = list(encode_trace_headers(context()).items())
+            values.append(("X-CACHEROUTE-TRACE-ID", "trace_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+            return values
+    with pytest.raises(TracePropagationError, match="header_conflict"):
+        decode_trace_headers(DuplicateHeaders(), clock=ManualTraceClock(NOW))
+
+
+def test_accepted_propagated_sampled_state_and_warning_reasons():
+    sampled_headers = encode_trace_headers(context(sample_rate=1.0))
+    unsampled_headers = encode_trace_headers(context(sample_rate=0.0))
+    assert decode_trace_headers(sampled_headers, clock=ManualTraceClock(NOW)).sampled is True
+    assert decode_trace_headers(unsampled_headers, clock=ManualTraceClock(NOW)).sampled is False
+    assert sample_rate_warning_reason("0.0") is None
+    assert sample_rate_warning_reason("bad") == "trace_sample_rate_malformed"
+    assert sample_rate_warning_reason("nan") == "trace_sample_rate_non_finite"
+    assert sample_rate_warning_reason("-0.1") == "trace_sample_rate_below_zero"
+    assert sample_rate_warning_reason("1.1") == "trace_sample_rate_above_one"
+
+
+@pytest.mark.parametrize(("value", "expected"), [
+    (None, RuntimeProfile.LEGACY),
+    ("legacy", RuntimeProfile.LEGACY),
+    ("test/mock", RuntimeProfile.TEST_MOCK),
+    ("v1", RuntimeProfile.V1),
+    ("auto", RuntimeProfile.LEGACY),
+])
+def test_scheduler_and_proxy_current_startup_resolution(value, expected):
+    # Both current services pass v1_available=False into the shared startup helper.
+    assert resolve_observability_startup(value, "0.0", v1_available=False).runtime_profile is expected

--- a/test/observability/test_scheduler_proxy_production_paths.py
+++ b/test/observability/test_scheduler_proxy_production_paths.py
@@ -1,0 +1,133 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+import pytest
+
+from cacheroute.contracts.v1 import OutcomeCode
+from cacheroute.observability import ManualTraceClock, TraceCollector, create_trace_context, encode_trace_headers
+from cacheroute.observability.propagation import RESERVED_TRACE_HEADERS, TRACE_ID_HEADER
+from cacheroute.observability.v1 import TraceComponent, TraceProvenance, TraceStageName
+from cacheroute.runtime import RuntimeProfile
+from proxy.queue.manager import QueueManager, _EMPTY_STREAM, _DOWNSTREAM_FAILED, _REQUEST_CANCELLED
+from proxy.queue.task import ProxyTask
+from proxy.proxy import build_cacheroute_meta, build_proxy_trace
+from scheduler.scheduler import build_proxy_headers, resolve_scheduler_observability_startup
+
+NOW = datetime(2026, 8, 4, 12, tzinfo=timezone.utc)
+TRACE_ID = "trace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+
+def _app(profile=RuntimeProfile.LEGACY, rate=1.0):
+    return SimpleNamespace(state=SimpleNamespace(runtime_profile=profile, trace_sample_rate=rate, trace_clock=ManualTraceClock(NOW)))
+
+
+def _request(headers, app=None):
+    return SimpleNamespace(headers=headers, app=app or _app())
+
+
+def _req_obj(rid=42, injection="text"):
+    return SimpleNamespace(
+        Request_ID=rid,
+        Prompt=SimpleNamespace(token_length=1, model="m", user_prompt="prompt", stream=True),
+        Service=SimpleNamespace(Knowledge_length=0, Injection_type=injection, Enable_know_injection=False, Knowledge_List=[]),
+        Task=SimpleNamespace(KDN_server_addr="kdn"),
+    )
+
+
+def _task(clock=None, sampled=True):
+    clock = clock or ManualTraceClock(NOW)
+    ctx = create_trace_context("42", RuntimeProfile.LEGACY, sample_rate=1.0 if sampled else 0.0, clock=clock, trace_id=TRACE_ID)
+    collector = TraceCollector(ctx, clock=clock, id_factory=iter(["stage_prepare", "stage_ready", "stage_completion", "stage_first", "stage_decode"]).__next__)
+    provenance = TraceProvenance(source_component=TraceComponent.PROXY, runtime_profile=ctx.runtime_profile, captured_at=clock.utc_now())
+    return ProxyTask(42, _req_obj(), {}, "inst", "127.0.0.1", 9001, "/v1/chat/completions", trace_context=ctx, trace_collector=collector, trace_provenance=provenance)
+
+
+def test_scheduler_headers_overwrite_authorization_and_payload_boundary():
+    app = _app()
+    raw = {"authorization": "Bearer kept", **{name: "client" for name in RESERVED_TRACE_HEADERS}}
+    headers = build_proxy_headers(app, raw, 99)
+    assert headers["authorization"] == "Bearer kept"
+    assert headers["scheduler-request-id"] == "99"
+    assert all(headers[name] != "client" for name in RESERVED_TRACE_HEADERS)
+    assert set(headers) == set(RESERVED_TRACE_HEADERS) | {"authorization"}
+    payload = {"Request_ID": 99, "Prompt": {"user_prompt": "secret"}}
+    assert not (set(payload) & set(RESERVED_TRACE_HEADERS))
+    assert resolve_scheduler_observability_startup("auto", 1.0).runtime_profile is RuntimeProfile.LEGACY
+
+
+def test_proxy_acceptance_and_fallback_reasons():
+    headers = encode_trace_headers(create_trace_context("42", RuntimeProfile.LEGACY, sample_rate=1.0, clock=ManualTraceClock(NOW), trace_id=TRACE_ID))
+    ctx, collector, provenance = build_proxy_trace(_request(headers), 42)
+    assert ctx.trace_id == TRACE_ID
+    assert collector.context is ctx
+    assert provenance.source_component is TraceComponent.PROXY
+    assert provenance.runtime_profile is RuntimeProfile.LEGACY
+
+    malformed = dict(headers)
+    malformed[TRACE_ID_HEADER] = "bad"
+    fallback, _, _ = build_proxy_trace(_request(malformed), 42)
+    assert fallback.request_id == "42" and fallback.trace_id != TRACE_ID
+
+    mismatch, _, _ = build_proxy_trace(_request(headers), 43)
+    assert mismatch.request_id == "43" and mismatch.trace_id != TRACE_ID
+
+    profile_mismatch, _, _ = build_proxy_trace(_request(headers, _app(RuntimeProfile.TEST_MOCK)), 42)
+    assert profile_mismatch.runtime_profile is RuntimeProfile.TEST_MOCK
+    assert profile_mismatch.trace_id != TRACE_ID
+
+
+def test_unsampled_context_produces_no_stages_and_legacy_meta_keys_unchanged():
+    task = _task(sampled=False)
+    manager = QueueManager()
+    task.prepare_queue_stage_id = manager._start_stage(task, TraceStageName.PROXY_PREPARE_QUEUE)
+    manager._finish_stage(task, task.prepare_queue_stage_id, OutcomeCode.SUCCESS)
+    manager._finalize_trace(task, OutcomeCode.SUCCESS)
+    assert task.request_trace is not None
+    assert task.request_trace.stages == ()
+    task.trace["proxy_enqueue_ms"] = 1
+    assert list(build_cacheroute_meta(task)) == ["trace", "kv_ack", "kv_ready_kids", "text_only_kids", "miss_kids", "error"]
+    assert build_cacheroute_meta(task)["trace"] == {"proxy_enqueue_ms": 1}
+
+
+def test_ready_stage_excludes_reservation_time_and_prepare_is_monotonic():
+    clock = ManualTraceClock(NOW)
+    task = _task(clock)
+    manager = QueueManager()
+    task.prepare_queue_stage_id = manager._start_stage(task, TraceStageName.PROXY_PREPARE_QUEUE)
+    clock.advance(nanoseconds=5_000_000)
+    manager._finish_stage(task, task.prepare_queue_stage_id, OutcomeCode.SUCCESS)
+    clock.advance(nanoseconds=100_000_000)  # reservation/prediction time before canonical ready queue
+    task.ready_queue_stage_id = manager._start_stage(task, TraceStageName.PROXY_READY_QUEUE)
+    clock.advance(nanoseconds=7_000_000)
+    manager._finish_stage(task, task.ready_queue_stage_id, OutcomeCode.SUCCESS)
+    manager._finalize_trace(task, OutcomeCode.SUCCESS)
+    stages = {stage.name: stage for stage in task.request_trace.stages}
+    assert stages[TraceStageName.PROXY_PREPARE_QUEUE].elapsed_ns == 5_000_000
+    assert stages[TraceStageName.PROXY_READY_QUEUE].elapsed_ns == 7_000_000
+
+
+def test_streaming_nonstreaming_empty_failure_and_safe_errors_have_valid_hierarchy():
+    clock = ManualTraceClock(NOW)
+    task = _task(clock)
+    manager = QueueManager()
+    task.completion_stage_id = manager._start_stage(task, TraceStageName.COMPLETION)
+    task.first_token_stage_id = manager._start_stage(task, TraceStageName.FIRST_TOKEN, parent=task.completion_stage_id)
+    clock.advance(nanoseconds=3)
+    manager._finish_stage(task, task.first_token_stage_id, OutcomeCode.FAILED, _EMPTY_STREAM)
+    task.trace_collector.skip_stage(TraceStageName.DECODE, task.trace_provenance, reason="stream_ended_before_decode", parent_stage_id=task.completion_stage_id)
+    manager._finish_stage(task, task.completion_stage_id, OutcomeCode.FAILED, _EMPTY_STREAM)
+    manager._finalize_trace(task, OutcomeCode.FAILED, _EMPTY_STREAM)
+    assert task.request_trace.outcome is OutcomeCode.FAILED
+    assert task.request_trace.error == _EMPTY_STREAM
+    assert all(stage.state.value != "running" for stage in task.request_trace.stages)
+    assert [stage.sequence for stage in task.request_trace.stages] == [0, 1, 2]
+    assert all("prompt" not in task.request_trace.model_dump_json().lower() for _ in [0])
+
+    for error in (_EMPTY_STREAM, _DOWNSTREAM_FAILED, _REQUEST_CANCELLED):
+        assert "exception" not in error.message
+        assert "authorization" not in error.message
+
+
+def test_no_reserved_header_sent_to_instance_contract():
+    task = _task()
+    task.instance_body = {"model": "m", "messages": [{"role": "user", "content": "prompt"}], "stream": True}
+    assert not (set(task.instance_body) & set(RESERVED_TRACE_HEADERS))

--- a/test/observability/test_scheduler_proxy_production_paths.py
+++ b/test/observability/test_scheduler_proxy_production_paths.py
@@ -1,133 +1,302 @@
+from contextlib import suppress
 from datetime import datetime, timezone
 from types import SimpleNamespace
+import asyncio
+import json
+import logging
+import importlib
+
 import pytest
 
+from core import Request as SchedulerRequest
 from cacheroute.contracts.v1 import OutcomeCode
 from cacheroute.observability import ManualTraceClock, TraceCollector, create_trace_context, encode_trace_headers
 from cacheroute.observability.propagation import RESERVED_TRACE_HEADERS, TRACE_ID_HEADER
-from cacheroute.observability.v1 import TraceComponent, TraceProvenance, TraceStageName
+from cacheroute.observability.v1 import TraceComponent, TraceStageName
 from cacheroute.runtime import RuntimeProfile
 from proxy.queue.manager import QueueManager, _EMPTY_STREAM, _DOWNSTREAM_FAILED, _REQUEST_CANCELLED
 from proxy.queue.task import ProxyTask
-from proxy.proxy import build_cacheroute_meta, build_proxy_trace
+from proxy.proxy import build_body_for_instance, build_cacheroute_meta, build_proxy_trace, recover_request_from_payload, resolve_proxy_observability_startup
 from scheduler.scheduler import build_proxy_headers, resolve_scheduler_observability_startup
 
 NOW = datetime(2026, 8, 4, 12, tzinfo=timezone.utc)
 TRACE_ID = "trace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 
-def _app(profile=RuntimeProfile.LEGACY, rate=1.0):
-    return SimpleNamespace(state=SimpleNamespace(runtime_profile=profile, trace_sample_rate=rate, trace_clock=ManualTraceClock(NOW)))
+class _CaseDone(Exception):
+    pass
+
+
+def _app(profile=RuntimeProfile.LEGACY, rate=1.0, clock=None):
+    return SimpleNamespace(state=SimpleNamespace(runtime_profile=profile, trace_sample_rate=rate, trace_clock=clock or ManualTraceClock(NOW)))
 
 
 def _request(headers, app=None):
     return SimpleNamespace(headers=headers, app=app or _app())
 
 
-def _req_obj(rid=42, injection="text"):
-    return SimpleNamespace(
-        Request_ID=rid,
-        Prompt=SimpleNamespace(token_length=1, model="m", user_prompt="prompt", stream=True),
-        Service=SimpleNamespace(Knowledge_length=0, Injection_type=injection, Enable_know_injection=False, Knowledge_List=[]),
-        Task=SimpleNamespace(KDN_server_addr="kdn"),
+def _scheduler_request(rid=42, *, stream=True, endpoint="chat/completions"):
+    payload = {
+        "model": "unit-model",
+        "max_tokens": 4,
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "stream": stream,
+    }
+    url = "/v1/chat/completions" if endpoint == "chat/completions" else "/v1/completions"
+    if endpoint == "chat/completions":
+        payload["messages"] = [{"role": "user", "content": "hello"}]
+    else:
+        payload["prompt"] = "hello"
+    req = SchedulerRequest.build_request(url, payload, "127.0.0.1", rid)
+    req.Task.KDN_server_addr = "kdn.local:7003"
+    req.Task.P_proxy_id = "proxy_a"
+    req.Task.P_proxy_addr = "127.0.0.1"
+    req.Task.P_proxy_port = 8002
+    return req
+
+
+def _task_from_request(req_obj, *, sampled=True, trace_id=TRACE_ID, clock=None):
+    clock = clock or ManualTraceClock(NOW)
+    ctx = create_trace_context(req_obj.Request_ID, RuntimeProfile.LEGACY, sample_rate=1.0 if sampled else 0.0, clock=clock, trace_id=trace_id)
+    collector = TraceCollector(
+        ctx,
+        clock=clock,
+        id_factory=iter(["stage_prepare", "stage_ready", "stage_completion", "stage_first", "stage_decode"]).__next__,
+    )
+    from cacheroute.observability.v1 import TraceProvenance
+    provenance = TraceProvenance(source_component=TraceComponent.PROXY, runtime_profile=ctx.runtime_profile, captured_at=clock.utc_now())
+    mode = "chat" if req_obj.Service.Endpoint_type == "chat/completions" else "completions"
+    return ProxyTask(
+        req_obj.Request_ID,
+        req_obj,
+        build_body_for_instance(req_obj, mode=mode),
+        "inst-a",
+        "127.0.0.1",
+        9001,
+        f"/v1/{req_obj.Service.Endpoint_type}",
+        kdn_addr=req_obj.Task.KDN_server_addr,
+        trace_context=ctx,
+        trace_collector=collector,
+        trace_provenance=provenance,
     )
 
 
-def _task(clock=None, sampled=True):
-    clock = clock or ManualTraceClock(NOW)
-    ctx = create_trace_context("42", RuntimeProfile.LEGACY, sample_rate=1.0 if sampled else 0.0, clock=clock, trace_id=TRACE_ID)
-    collector = TraceCollector(ctx, clock=clock, id_factory=iter(["stage_prepare", "stage_ready", "stage_completion", "stage_first", "stage_decode"]).__next__)
-    provenance = TraceProvenance(source_component=TraceComponent.PROXY, runtime_profile=ctx.runtime_profile, captured_at=clock.utc_now())
-    return ProxyTask(42, _req_obj(), {}, "inst", "127.0.0.1", 9001, "/v1/chat/completions", trace_context=ctx, trace_collector=collector, trace_provenance=provenance)
+async def _drain_until_done(task, timeout=2.0):
+    chunks = []
+    while True:
+        item = await asyncio.wait_for(task.response_queue.get(), timeout=timeout)
+        if item is None:
+            return chunks
+        chunks.append(item)
 
 
-def test_scheduler_headers_overwrite_authorization_and_payload_boundary():
-    app = _app()
-    raw = {"authorization": "Bearer kept", **{name: "client" for name in RESERVED_TRACE_HEADERS}}
-    headers = build_proxy_headers(app, raw, 99)
+async def _run_real_queue(monkeypatch, task, chunks=(), *, fail_at=None, cancel_after_first=False):
+    calls = []
+    manager = QueueManager()
+    manager._READY_DEQUEUE_INTERVAL_S = 0.0
+    task.trace["preexisting"] = 7
+
+    async def fake_forward_request(url, data, use_chunked=False):
+        calls.append({"url": url, "data": data.copy(), "use_chunked": use_chunked})
+        if fail_at == "before_first":
+            raise RuntimeError("raw downstream boom should not enter trace")
+        for index, chunk in enumerate(chunks):
+            yield chunk
+            if cancel_after_first and index == 0:
+                await asyncio.sleep(10)
+            if fail_at == "after_first" and index == 0:
+                raise RuntimeError("raw downstream boom should not enter trace")
+
+    monkeypatch.setattr("proxy.queue.manager.forward_request", fake_forward_request)
+    await manager.enqueue_prepare(task)
+    output_task = asyncio.create_task(_drain_until_done(task))
+    if cancel_after_first:
+        await asyncio.sleep(0.05)
+        for worker in manager._worker_tasks.values():
+            worker.cancel()
+    try:
+        output = await output_task
+    finally:
+        for worker in manager._worker_tasks.values():
+            worker.cancel()
+        await asyncio.gather(*manager._worker_tasks.values(), return_exceptions=True)
+    return manager, output, calls
+
+
+def _assert_no_running_and_valid_refs(request_trace):
+    assert request_trace is not None
+    assert all(stage.state.value != "running" for stage in request_trace.stages)
+    assert [stage.sequence for stage in request_trace.stages] == sorted(stage.sequence for stage in request_trace.stages)
+    ids = {stage.stage_id for stage in request_trace.stages}
+    assert all(stage.parent_stage_id is None or stage.parent_stage_id in ids for stage in request_trace.stages)
+    assert all(stage.provenance.source_component is TraceComponent.PROXY for stage in request_trace.stages)
+
+
+def test_startup_warning_reason_codes_are_bounded_and_non_blocking(caplog):
+    assert resolve_scheduler_observability_startup("legacy", "0.0").sample_rate_warning_reason is None
+    for value, reason in [("bad", "trace_sample_rate_malformed"), ("nan", "trace_sample_rate_non_finite"), ("-1", "trace_sample_rate_below_zero"), ("2", "trace_sample_rate_above_one")]:
+        config = resolve_proxy_observability_startup("auto", value)
+        assert config.trace_sample_rate == 0.0
+        assert config.runtime_profile is RuntimeProfile.LEGACY
+        assert config.sample_rate_warning_reason == reason
+    caplog.set_level(logging.WARNING)
+    config = resolve_scheduler_observability_startup("legacy", "bad")
+    logging.getLogger("scheduler").warning("[Scheduler] observability startup warning reason=%s", config.sample_rate_warning_reason)
+    assert caplog.text.count("trace_sample_rate_malformed") == 1
+    assert "bad" not in caplog.text
+    headers = build_proxy_headers(_app(rate=config.trace_sample_rate), {"authorization": "Bearer kept"}, 11)
+    assert headers["scheduler-request-id"] == "11"
+
+
+def test_scheduler_headers_overwrite_authorization_and_actual_payload_boundary():
+    req = _scheduler_request(99)
+    payload = req.to_payload()
+    headers = build_proxy_headers(_app(), {"authorization": "Bearer kept", **{name: "client" for name in RESERVED_TRACE_HEADERS}}, req.Request_ID)
     assert headers["authorization"] == "Bearer kept"
     assert headers["scheduler-request-id"] == "99"
     assert all(headers[name] != "client" for name in RESERVED_TRACE_HEADERS)
-    assert set(headers) == set(RESERVED_TRACE_HEADERS) | {"authorization"}
-    payload = {"Request_ID": 99, "Prompt": {"user_prompt": "secret"}}
     assert not (set(payload) & set(RESERVED_TRACE_HEADERS))
-    assert resolve_scheduler_observability_startup("auto", 1.0).runtime_profile is RuntimeProfile.LEGACY
+    assert recover_request_from_payload(payload).Request_ID == req.Request_ID
 
 
-def test_proxy_acceptance_and_fallback_reasons():
+def test_proxy_acceptance_fallback_and_deterministic_local_sampling():
     headers = encode_trace_headers(create_trace_context("42", RuntimeProfile.LEGACY, sample_rate=1.0, clock=ManualTraceClock(NOW), trace_id=TRACE_ID))
     ctx, collector, provenance = build_proxy_trace(_request(headers), 42)
-    assert ctx.trace_id == TRACE_ID
+    assert ctx.trace_id == TRACE_ID and ctx.sampled is True
     assert collector.context is ctx
     assert provenance.source_component is TraceComponent.PROXY
-    assert provenance.runtime_profile is RuntimeProfile.LEGACY
-
     malformed = dict(headers)
     malformed[TRACE_ID_HEADER] = "bad"
-    fallback, _, _ = build_proxy_trace(_request(malformed), 42)
-    assert fallback.request_id == "42" and fallback.trace_id != TRACE_ID
-
-    mismatch, _, _ = build_proxy_trace(_request(headers), 43)
-    assert mismatch.request_id == "43" and mismatch.trace_id != TRACE_ID
-
-    profile_mismatch, _, _ = build_proxy_trace(_request(headers, _app(RuntimeProfile.TEST_MOCK)), 42)
-    assert profile_mismatch.runtime_profile is RuntimeProfile.TEST_MOCK
-    assert profile_mismatch.trace_id != TRACE_ID
+    first, _, _ = build_proxy_trace(_request(malformed), 42)
+    second, _, _ = build_proxy_trace(_request(malformed), 42)
+    assert first.request_id == "42" and first.trace_id != TRACE_ID
+    assert first.sampled == first.sampled
+    mismatch, _, _ = build_proxy_trace(_request(headers, _app(RuntimeProfile.TEST_MOCK)), 42)
+    assert mismatch.runtime_profile is RuntimeProfile.TEST_MOCK
 
 
-def test_unsampled_context_produces_no_stages_and_legacy_meta_keys_unchanged():
-    task = _task(sampled=False)
-    manager = QueueManager()
-    task.prepare_queue_stage_id = manager._start_stage(task, TraceStageName.PROXY_PREPARE_QUEUE)
-    manager._finish_stage(task, task.prepare_queue_stage_id, OutcomeCode.SUCCESS)
-    manager._finalize_trace(task, OutcomeCode.SUCCESS)
-    assert task.request_trace is not None
-    assert task.request_trace.stages == ()
-    task.trace["proxy_enqueue_ms"] = 1
-    assert list(build_cacheroute_meta(task)) == ["trace", "kv_ack", "kv_ready_kids", "text_only_kids", "miss_kids", "error"]
-    assert build_cacheroute_meta(task)["trace"] == {"proxy_enqueue_ms": 1}
+@pytest.mark.parametrize(("endpoint", "chunks", "expected_outcome", "expected_error"), [
+    ("chat/completions", [b"data: token\\n\\n", b"data: [DONE]\\n\\n"], OutcomeCode.SUCCESS, None),
+    ("completions", [json.dumps({"choices": [{"text": "ok"}]}).encode()], OutcomeCode.SUCCESS, None),
+    ("chat/completions", [], OutcomeCode.FAILED, _EMPTY_STREAM),
+])
+def test_real_ready_worker_success_nonstream_and_empty_paths(monkeypatch, endpoint, chunks, expected_outcome, expected_error):
+    async def scenario():
+        req = _scheduler_request(42, stream=endpoint == "chat/completions", endpoint=endpoint)
+        task = _task_from_request(req)
+        original_body = task.instance_body.copy()
+        original_trace = dict(task.trace)
+        _manager, output, calls = await _run_real_queue(monkeypatch, task, chunks=chunks)
+        assert output == chunks
+        assert calls and calls[0]["url"] == f"http://{task.instance_host}:{task.instance_port}{task.url_path}"
+        assert calls[0]["data"] == original_body
+        assert calls[0]["use_chunked"] is (endpoint == "chat/completions")
+        assert not (set(calls[0].get("headers", {})) & set(RESERVED_TRACE_HEADERS))
+        assert task.request_trace.outcome is expected_outcome
+        assert task.request_trace.error == expected_error
+        _assert_no_running_and_valid_refs(task.request_trace)
+        assert task.trace["preexisting"] == 7
+        assert all(item in task.trace.items() for item in original_trace.items())
+        names = [stage.name for stage in task.request_trace.stages]
+        assert TraceStageName.PROXY_PREPARE_QUEUE in names
+        assert TraceStageName.PROXY_READY_QUEUE in names
+        assert TraceStageName.COMPLETION in names
+        if endpoint == "completions":
+            skipped = [stage for stage in task.request_trace.stages if stage.state.value == "skipped"]
+            assert {stage.name for stage in skipped} == {TraceStageName.FIRST_TOKEN, TraceStageName.DECODE}
+    asyncio.run(scenario())
 
 
-def test_ready_stage_excludes_reservation_time_and_prepare_is_monotonic():
-    clock = ManualTraceClock(NOW)
-    task = _task(clock)
-    manager = QueueManager()
-    task.prepare_queue_stage_id = manager._start_stage(task, TraceStageName.PROXY_PREPARE_QUEUE)
-    clock.advance(nanoseconds=5_000_000)
-    manager._finish_stage(task, task.prepare_queue_stage_id, OutcomeCode.SUCCESS)
-    clock.advance(nanoseconds=100_000_000)  # reservation/prediction time before canonical ready queue
-    task.ready_queue_stage_id = manager._start_stage(task, TraceStageName.PROXY_READY_QUEUE)
-    clock.advance(nanoseconds=7_000_000)
-    manager._finish_stage(task, task.ready_queue_stage_id, OutcomeCode.SUCCESS)
-    manager._finalize_trace(task, OutcomeCode.SUCCESS)
-    stages = {stage.name: stage for stage in task.request_trace.stages}
-    assert stages[TraceStageName.PROXY_PREPARE_QUEUE].elapsed_ns == 5_000_000
-    assert stages[TraceStageName.PROXY_READY_QUEUE].elapsed_ns == 7_000_000
+@pytest.mark.parametrize(("fail_at", "expected_error"), [
+    ("before_first", _DOWNSTREAM_FAILED),
+    ("after_first", _DOWNSTREAM_FAILED),
+])
+def test_real_ready_worker_failure_paths(monkeypatch, fail_at, expected_error):
+    async def scenario():
+        req = _scheduler_request(42)
+        task = _task_from_request(req)
+        _manager, output, calls = await _run_real_queue(monkeypatch, task, chunks=[b"data: token\\n\\n"], fail_at=fail_at)
+        assert output == ([] if fail_at == "before_first" else [b"data: token\\n\\n"])
+        assert calls
+        assert task.request_trace.outcome is OutcomeCode.FAILED
+        assert task.request_trace.error == expected_error
+        assert "raw downstream" not in task.request_trace.model_dump_json()
+        _assert_no_running_and_valid_refs(task.request_trace)
+    asyncio.run(scenario())
 
 
-def test_streaming_nonstreaming_empty_failure_and_safe_errors_have_valid_hierarchy():
-    clock = ManualTraceClock(NOW)
-    task = _task(clock)
-    manager = QueueManager()
-    task.completion_stage_id = manager._start_stage(task, TraceStageName.COMPLETION)
-    task.first_token_stage_id = manager._start_stage(task, TraceStageName.FIRST_TOKEN, parent=task.completion_stage_id)
-    clock.advance(nanoseconds=3)
-    manager._finish_stage(task, task.first_token_stage_id, OutcomeCode.FAILED, _EMPTY_STREAM)
-    task.trace_collector.skip_stage(TraceStageName.DECODE, task.trace_provenance, reason="stream_ended_before_decode", parent_stage_id=task.completion_stage_id)
-    manager._finish_stage(task, task.completion_stage_id, OutcomeCode.FAILED, _EMPTY_STREAM)
-    manager._finalize_trace(task, OutcomeCode.FAILED, _EMPTY_STREAM)
-    assert task.request_trace.outcome is OutcomeCode.FAILED
-    assert task.request_trace.error == _EMPTY_STREAM
-    assert all(stage.state.value != "running" for stage in task.request_trace.stages)
-    assert [stage.sequence for stage in task.request_trace.stages] == [0, 1, 2]
-    assert all("prompt" not in task.request_trace.model_dump_json().lower() for _ in [0])
+@pytest.mark.parametrize("cancel_after_first", [False, True])
+def test_real_ready_worker_cancellation_paths(monkeypatch, cancel_after_first):
+    async def scenario():
+        req = _scheduler_request(42)
+        task = _task_from_request(req)
+        chunks = [b"data: token\\n\\n"] if cancel_after_first else []
 
-    for error in (_EMPTY_STREAM, _DOWNSTREAM_FAILED, _REQUEST_CANCELLED):
-        assert "exception" not in error.message
-        assert "authorization" not in error.message
+        async def fake_forward_request(url, data, use_chunked=False):
+            if not cancel_after_first:
+                await asyncio.sleep(10)
+                yield b""
+            else:
+                yield chunks[0]
+                await asyncio.sleep(10)
+
+        monkeypatch.setattr("proxy.queue.manager.forward_request", fake_forward_request)
+        manager = QueueManager(); manager._READY_DEQUEUE_INTERVAL_S = 0.0
+        await manager.enqueue_prepare(task)
+        await asyncio.sleep(0.05)
+        for worker in manager._worker_tasks.values():
+            worker.cancel()
+        with suppress(asyncio.CancelledError, TimeoutError):
+            await asyncio.wait_for(_drain_until_done(task), timeout=1.0)
+        await asyncio.gather(*manager._worker_tasks.values(), return_exceptions=True)
+        assert task.request_trace.outcome is OutcomeCode.CANCELLED
+        assert task.request_trace.error == _REQUEST_CANCELLED
+        _assert_no_running_and_valid_refs(task.request_trace)
+    asyncio.run(scenario())
 
 
-def test_no_reserved_header_sent_to_instance_contract():
-    task = _task()
-    task.instance_body = {"model": "m", "messages": [{"role": "user", "content": "prompt"}], "stream": True}
-    assert not (set(task.instance_body) & set(RESERVED_TRACE_HEADERS))
+def test_unsampled_real_queue_records_no_stages_and_metadata_shapes(monkeypatch):
+    async def scenario():
+        req = _scheduler_request(42)
+        task = _task_from_request(req, sampled=False)
+        _manager, output, _calls = await _run_real_queue(monkeypatch, task, chunks=[b"data: token\\n\\n"])
+        assert output == [b"data: token\\n\\n"]
+        assert task.request_trace.stages == ()
+        meta = build_cacheroute_meta(task)
+        assert list(meta) == ["trace", "kv_ack", "kv_ready_kids", "text_only_kids", "miss_kids", "error"]
+        sse = ("event: cacheroute_meta\n" f"data: {json.dumps(meta, ensure_ascii=False)}\n\n").encode()
+        assert sse.startswith(b"event: cacheroute_meta\n")
+        nonstream = {"choices": [], "_cacheroute_meta": meta}
+        assert list(nonstream) == ["choices", "_cacheroute_meta"]
+    asyncio.run(scenario())
+
+
+def test_cpu_only_scheduler_to_proxy_integration_with_real_workers(monkeypatch):
+    async def scenario():
+        scheduler_clock = ManualTraceClock(NOW)
+        req = _scheduler_request(123)
+        def fixed_context(request_id, runtime_profile, *, sample_rate=0.0, clock=None, trace_id=None):
+            return create_trace_context(request_id, runtime_profile, sample_rate=1.0, clock=clock, trace_id=TRACE_ID)
+        scheduler_module = importlib.import_module("scheduler.scheduler")
+        monkeypatch.setattr(scheduler_module, "create_trace_context", fixed_context)
+        headers = build_proxy_headers(_app(clock=scheduler_clock), {}, req.Request_ID)
+        trace_id = headers[TRACE_ID_HEADER]
+        recovered = recover_request_from_payload(req.to_payload())
+        proxy_clock = ManualTraceClock(NOW)
+        context, _collector, provenance = build_proxy_trace(_request(headers, _app(clock=proxy_clock)), recovered.Request_ID)
+        collector = TraceCollector(context, clock=proxy_clock, id_factory=iter(["stage_prepare", "stage_ready", "stage_completion", "stage_first", "stage_decode"]).__next__)
+        task = ProxyTask(
+            recovered.Request_ID, recovered, build_body_for_instance(recovered, mode="chat"),
+            "inst-a", "127.0.0.1", 9001, "/v1/chat/completions",
+            kdn_addr=recovered.Task.KDN_server_addr,
+            trace_context=context, trace_collector=collector, trace_provenance=provenance,
+        )
+        _manager, _output, calls = await _run_real_queue(monkeypatch, task, chunks=[b"data: token\\n\\n"])
+        assert task.trace_context.request_id == str(req.Request_ID)
+        assert task.trace_context.trace_id == trace_id
+        assert task.request_trace.context.request_id == str(req.Request_ID)
+        assert task.request_trace.context.trace_id == trace_id
+        assert calls[0]["data"] == task.instance_body
+        assert not (set(calls[0]["data"]) & set(RESERVED_TRACE_HEADERS))
+    asyncio.run(scenario())

--- a/test/observability/test_scheduler_proxy_production_paths.py
+++ b/test/observability/test_scheduler_proxy_production_paths.py
@@ -10,7 +10,7 @@ import pytest
 
 from core import Request as SchedulerRequest
 from cacheroute.contracts.v1 import OutcomeCode
-from cacheroute.observability import ManualTraceClock, TraceCollector, create_trace_context, encode_trace_headers
+from cacheroute.observability import ManualTraceClock, TraceCollector, create_trace_context, encode_trace_headers, is_trace_sampled
 from cacheroute.observability.propagation import RESERVED_TRACE_HEADERS, TRACE_ID_HEADER
 from cacheroute.observability.v1 import TraceComponent, TraceStageName
 from cacheroute.runtime import RuntimeProfile
@@ -124,6 +124,46 @@ async def _run_real_queue(monkeypatch, task, chunks=(), *, fail_at=None, cancel_
     return manager, output, calls
 
 
+async def _run_timed_real_queue(monkeypatch, task, clock):
+    calls = []
+    manager = QueueManager()
+    manager._READY_DEQUEUE_INTERVAL_S = 0.0
+
+    def start_without_workers(instance_id):
+        manager._ensure_instance_reservation_state(instance_id)
+    monkeypatch.setattr(manager, "_start_workers_for_instance", start_without_workers)
+
+    original_reserve = manager._reserve_ready_task
+    async def reserve_with_prediction_time(reserved_task, now_s=None):
+        clock.advance(nanoseconds=100_000_000)
+        await original_reserve(reserved_task, now_s=now_s)
+    monkeypatch.setattr(manager, "_reserve_ready_task", reserve_with_prediction_time)
+
+    async def dispatch_wait(wait_task, instance_id):
+        clock.advance(nanoseconds=7_000_000)
+        wait_task.has_started_forward = True
+    monkeypatch.setattr(manager, "_wait_dispatch_turn", dispatch_wait)
+
+    async def timed_forward_request(url, data, use_chunked=False):
+        calls.append({"url": url, "data": data.copy(), "use_chunked": use_chunked})
+        clock.advance(nanoseconds=11_000_000)
+        yield b"data: token\n\n"
+        clock.advance(nanoseconds=13_000_000)
+
+    monkeypatch.setattr("proxy.queue.manager.forward_request", timed_forward_request)
+    await manager.enqueue_prepare(task)
+    clock.advance(nanoseconds=5_000_000)
+    prepare_worker = asyncio.create_task(manager._prepare_dispatch_loop(task.instance_id))
+    ready_worker = asyncio.create_task(manager._ready_worker_loop(task.instance_id, 0))
+    try:
+        output = await _drain_until_done(task)
+    finally:
+        for worker in (prepare_worker, ready_worker):
+            worker.cancel()
+        await asyncio.gather(prepare_worker, ready_worker, return_exceptions=True)
+    return output, calls
+
+
 def _assert_no_running_and_valid_refs(request_trace):
     assert request_trace is not None
     assert all(stage.state.value != "running" for stage in request_trace.stages)
@@ -168,10 +208,21 @@ def test_proxy_acceptance_fallback_and_deterministic_local_sampling():
     assert provenance.source_component is TraceComponent.PROXY
     malformed = dict(headers)
     malformed[TRACE_ID_HEADER] = "bad"
-    first, _, _ = build_proxy_trace(_request(malformed), 42)
-    second, _, _ = build_proxy_trace(_request(malformed), 42)
-    assert first.request_id == "42" and first.trace_id != TRACE_ID
-    assert first.sampled == first.sampled
+    fallback_id = "trace_cccccccccccccccccccccccccccccccc"
+    proxy_module = importlib.import_module("proxy.proxy")
+    def fixed_fallback(request_id, runtime_profile, *, sample_rate=0.0, clock=None, trace_id=None):
+        return create_trace_context(request_id, runtime_profile, sample_rate=sample_rate, clock=clock, trace_id=fallback_id)
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(proxy_module, "create_trace_context", fixed_fallback)
+        app = _app(rate=0.5)
+        first, _, _ = build_proxy_trace(_request(malformed, app), 42)
+        second, _, _ = build_proxy_trace(_request(malformed, app), 42)
+    finally:
+        monkeypatch.undo()
+    assert first.request_id == "42" and first.trace_id == fallback_id
+    assert second.trace_id == fallback_id
+    assert first.sampled == second.sampled == is_trace_sampled(fallback_id, 0.5)
     mismatch, _, _ = build_proxy_trace(_request(headers, _app(RuntimeProfile.TEST_MOCK)), 42)
     assert mismatch.runtime_profile is RuntimeProfile.TEST_MOCK
 
@@ -299,4 +350,45 @@ def test_cpu_only_scheduler_to_proxy_integration_with_real_workers(monkeypatch):
         assert task.request_trace.context.trace_id == trace_id
         assert calls[0]["data"] == task.instance_body
         assert not (set(calls[0]["data"]) & set(RESERVED_TRACE_HEADERS))
+    asyncio.run(scenario())
+
+
+
+def test_skip_stage_failure_is_non_blocking_for_nonstream_and_empty(monkeypatch):
+    async def scenario():
+        for endpoint, chunks, expected_error in (
+            ("completions", [json.dumps({"choices": [{"text": "ok"}]}).encode()], None),
+            ("chat/completions", [], _EMPTY_STREAM),
+        ):
+            req = _scheduler_request(42, stream=endpoint == "chat/completions", endpoint=endpoint)
+            task = _task_from_request(req)
+            original_business_error = task.error
+            def broken_skip_stage(*args, **kwargs):
+                raise ValueError("unsafe model detail must not be logged")
+            monkeypatch.setattr(task.trace_collector, "skip_stage", broken_skip_stage)
+            _manager, output, calls = await _run_real_queue(monkeypatch, task, chunks=chunks)
+            assert output == chunks
+            assert calls
+            assert task.error == original_business_error
+            assert task.request_trace.error == expected_error
+            _assert_no_running_and_valid_refs(task.request_trace)
+    asyncio.run(scenario())
+
+
+def test_real_methods_have_deterministic_elapsed_boundaries(monkeypatch):
+    async def scenario():
+        clock = ManualTraceClock(NOW)
+        req = _scheduler_request(42)
+        task = _task_from_request(req, clock=clock)
+        output, calls = await _run_timed_real_queue(monkeypatch, task, clock)
+        assert output == [b"data: token\n\n"]
+        assert calls and calls[0]["use_chunked"] is True
+        stages = {stage.name: stage for stage in task.request_trace.stages}
+        assert stages[TraceStageName.PROXY_PREPARE_QUEUE].elapsed_ns == 5_000_000
+        assert stages[TraceStageName.PROXY_READY_QUEUE].elapsed_ns == 7_000_000
+        assert stages[TraceStageName.FIRST_TOKEN].elapsed_ns == 11_000_000
+        assert stages[TraceStageName.DECODE].elapsed_ns == 13_000_000
+        assert stages[TraceStageName.COMPLETION].elapsed_ns == 24_000_000
+        assert stages[TraceStageName.PROXY_READY_QUEUE].elapsed_ns != 107_000_000
+        _assert_no_running_and_valid_refs(task.request_trace)
     asyncio.run(scenario())

--- a/test/test_repository_governance.py
+++ b/test/test_repository_governance.py
@@ -250,11 +250,12 @@ def test_canonical_service_contract_dependencies_are_allowed():
 
 def test_canonical_observability_dependencies_are_allowed():
     allowed = {
-        "__future__", "dataclasses", "datetime", "enum", "math", "re", "time",
+            "__future__", "collections.abc", "dataclasses", "datetime", "enum",
+            "hashlib", "math", "re", "time",
         "typing", "uuid", "pydantic", "cacheroute.runtime", "cacheroute.topology",
         "cacheroute.cache", "cacheroute.contracts.v1.common",
         "cacheroute.contracts.v1.errors", "clock", "collector", "legacy_proxy",
-        "enums", "models", "v1",
+            "enums", "models", "propagation", "v1", "v1.models",
     }
     for path in (ROOT / "src/cacheroute/observability").rglob("*.py"):
         tree = ast.parse(path.read_text(encoding="utf-8"))

--- a/test/test_repository_governance.py
+++ b/test/test_repository_governance.py
@@ -255,7 +255,7 @@ def test_canonical_observability_dependencies_are_allowed():
         "typing", "uuid", "pydantic", "cacheroute.runtime", "cacheroute.topology",
         "cacheroute.cache", "cacheroute.contracts.v1.common",
         "cacheroute.contracts.v1.errors", "clock", "collector", "legacy_proxy",
-            "enums", "models", "propagation", "v1", "v1.models",
+            "enums", "models", "propagation", "startup", "v1", "v1.models",
     }
     for path in (ROOT / "src/cacheroute/observability").rglob("*.py"):
         tree = ast.parse(path.read_text(encoding="utf-8"))
@@ -268,6 +268,26 @@ def test_canonical_observability_dependencies_are_allowed():
         }
         assert imports <= allowed, (path.relative_to(ROOT), imports - allowed)
         assert "sys.path" not in path.read_text(encoding="utf-8")
+
+
+def test_internal_trace_header_vocabulary_has_single_owner_and_services_import_it():
+    owner = ROOT / "src/cacheroute/observability/propagation.py"
+    header_literals = {
+        "scheduler-request-id",
+        "x-cacheroute-trace-version",
+        "x-cacheroute-trace-id",
+        "x-cacheroute-runtime-profile",
+        "x-cacheroute-trace-sampled",
+        "x-cacheroute-trace-created-at",
+    }
+    for literal in header_literals:
+        owners = {path.relative_to(ROOT) for path in _tracked_files() if path.suffix == ".py" and literal in path.read_text(encoding="utf-8")}
+        assert owners <= {owner.relative_to(ROOT), Path("test/observability/test_propagation.py"), Path("test/observability/test_scheduler_proxy_production_paths.py"), Path("test/test_repository_governance.py")}
+    for relative in (Path("scheduler/scheduler.py"), Path("proxy/proxy.py")):
+        text = (ROOT / relative).read_text(encoding="utf-8")
+        assert "cacheroute.observability" in text
+    assert "extra_headers=extra_headers" in (ROOT / "scheduler/scheduler.py").read_text(encoding="utf-8")
+    assert "extra_headers" not in (ROOT / "proxy/queue/manager.py").read_text(encoding="utf-8")
 
 
 def test_observability_does_not_duplicate_canonical_model_classes():

--- a/test/test_wheel_install.py
+++ b/test/test_wheel_install.py
@@ -55,6 +55,8 @@ REQUIRED_CANONICAL_FOUNDATION = {
     "cacheroute/observability/clock.py",
     "cacheroute/observability/collector.py",
     "cacheroute/observability/legacy_proxy.py",
+    "cacheroute/observability/propagation.py",
+    "cacheroute/observability/startup.py",
     "cacheroute/observability/v1/__init__.py",
     "cacheroute/observability/v1/enums.py",
     "cacheroute/observability/v1/models.py",
@@ -220,6 +222,8 @@ import cacheroute.cache.models as cache_models
 import cacheroute.routing
 import cacheroute.routing.queue as routing_queue
 import cacheroute.observability
+import cacheroute.observability.propagation as observability_propagation
+import cacheroute.observability.startup as observability_startup
 import cacheroute.observability.v1
 import cacheroute.observability.v1.models as observability_models
 import cacheroute.contracts
@@ -237,7 +241,8 @@ modules = (core, core_runtime, proxy, instance, kdn_server, kdn_server.domain,
            legacy_domain_models, runtime_state, cacheroute.topology,
            topology_lmcache, cacheroute.cache, cache_models,
            cacheroute.routing, routing_queue,
-           cacheroute.observability, cacheroute.observability.v1, observability_models,
+           cacheroute.observability, observability_propagation, observability_startup,
+           cacheroute.observability.v1, observability_models,
            cacheroute.runtime, cacheroute.contracts, cacheroute.contracts.v1,
            canonical_common, canonical_errors, canonical_knowledge,
            canonical_cache_service, legacy_common, legacy_errors,
@@ -284,6 +289,12 @@ observability_identity_pairs = (
     (observability_models.LMCacheGatewayProfile, topology_lmcache.LMCacheGatewayProfile),
 )
 assert all(observability is canonical for observability, canonical in observability_identity_pairs)
+assert cacheroute.observability.create_trace_context is observability_propagation.create_trace_context
+assert cacheroute.observability.RESERVED_TRACE_HEADERS is observability_propagation.RESERVED_TRACE_HEADERS
+assert cacheroute.observability.resolve_observability_startup is observability_startup.resolve_observability_startup
+assert cacheroute.observability.sample_rate_warning_reason is observability_startup.sample_rate_warning_reason
+for module in (cacheroute.observability, observability_propagation, observability_startup):
+    assert Path(module.__file__).resolve().is_relative_to(Path(sys.prefix).resolve())
 assert importlib.util.find_spec("cacheroute_observability") is None
 assert runtime_state.utc_now is legacy_domain_models.utc_now
 assert legacy_common.VersionedMessage is canonical_common.VersionedMessage


### PR DESCRIPTION
### Motivation

- Phase 4A provided immutable observability models and clocks but did not create a usable request timeline that links Scheduler authority with Proxy-observed intervals.
- A narrow, compatibility-preserving internal propagation path is needed so the Scheduler can inject a canonical trace context and the Proxy can validate it, locally collect stages, and produce an immutable Proxy-local RequestTrace without changing public request/response behavior.

### Description

- Add a canonical propagation helper `src/cacheroute/observability/propagation.py` that owns the reserved header vocabulary, deterministic sampling, trace-id generation/validation, UTC created-at handling, and encode/decode round trips for `scheduler-request-id`, `x-cacheroute-trace-version`, `x-cacheroute-trace-id`, `x-cacheroute-runtime-profile`, `x-cacheroute-trace-sampled`, and `x-cacheroute-trace-created-at`.
- Update `src/cacheroute/observability/__init__.py` to expose only the reviewed, version-neutral exports from the new helper and keep v1 model exports unflattened.
- Make Scheduler produce and overwrite the complete reserved header set by adding `build_proxy_headers` and wiring runtime-profile and sample-rate resolution in `scheduler/scheduler.py` while preserving Authorization forwarding and the existing `scheduler-request-id` allocation.
- Make Proxy validate or fallback the propagated context after reconstructing the Scheduler payload by adding `build_proxy_trace`, creating a process-local `TraceCollector`, attaching optional canonical fields to `ProxyTask` (new optional `trace_context`, `trace_collector`, `request_trace`, `trace_provenance`, and active-stage IDs), and instrumenting prepare/ready/completion/first-token/decode lifecycle boundaries in `proxy/queue/manager.py` with bounded safe outcomes for empty streams, downstream failures, and cancellation.
- Preserve all public wire shapes and Legacy `trace` mapping; do not forward any reserved observability header from Proxy to Instance and keep all production behaviors (routing, queueing, injection, retries, timeouts, response payloads) unchanged.
- Add focused unit tests for propagation under `test/observability/test_propagation.py` and update documentation `doc/architecture/observability-v1.md` and the research inventory to document the trust boundary, header vocabulary, sampling, and Proxy-observed stage semantics.

### Testing

- `python3 -m compileall -q src test scheduler proxy` — PASSED.
- `python3 -m pytest -q test/test_repository_governance.py` — PASSED (13 tests).
- `git diff --check` and merge-base verification against commit `5562c223ad8900a5ced473ce10982ca7f827f117` — PASSED (baseline verified).
- Observability-focused and many contract/namespace tests were attempted but environment package-index/network restrictions prevented installing required runtime test dependencies (`pydantic`, `aiohttp`, `fastapi`, etc.), so the following were environment-blocked: `test/observability` collection (blocked by missing `pydantic`), `test/test_contract_foundation.py`, `test/test_contract_service_migration.py`, `test/test_namespace_layout.py` dependency-isolated checks (some checks failed due to missing deps before governance fixes), `test/test_source_checkout_imports.py` (blocked by missing `aiohttp`), `test/kdn` (blocked by missing `pydantic`), and instance-capability tests (blocked by `fastapi`/`aiohttp`).
- Wheel build harness (clean-copy wheel test) produced `cacheroute-0.1.9-py3-none-any.whl` in the test harness and passed the dependency-light clean-wheel import check, but a complete isolated wheel-install validation with all environment checks and final artifact hashing could not be completed due to external package-index/network restrictions.

Note: final branch `codex/issue-182-observability` head is `293d362d165ad7989a6e76a6c1ba03fe8d23e47e` (base merge commit verified `5562c223ad8900a5ced473ce10982ca7f827f117`), changed files include the new helper `src/cacheroute/observability/propagation.py`, `proxy/queue/task.py`, `proxy/queue/manager.py`, `proxy/proxy.py`, `scheduler/scheduler.py`, `src/cacheroute/observability/__init__.py`, docs `doc/architecture/observability-v1.md`, and tests `test/observability/test_propagation.py`. The implementation is intentionally best-effort and non-blocking: canonical traces are never exported to clients or forwarded to Instances and the production behavior remains observational and compatible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71567283448320a81a6326de1ba326)